### PR TITLE
asMap() now accepts the key as generic type asMap<T>()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0
+
+`asMap` now expects the key type, defaults to `dynamic` instead of `String`
+```diff
+-Pick.asMap(): Map<String, dynamic>
++Pick.asMap<T>(): Map<T, dynamic>
+```
+
 ## 0.2.0
 
 New API! 

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -84,13 +84,14 @@ class Pick {
     }
   }
 
-  Map<String, dynamic> asMap() {
-    _verifyNonNull("Map<String, dynamic>");
-    if (value is Map<String, dynamic>) {
-      return value as Map<String, dynamic>;
+  /// [K] is the key type
+  Map<K, dynamic> asMap<K>() {
+    _verifyNonNull("Map<$K, dynamic>");
+    if (value is Map<K, dynamic>) {
+      return value as Map<K, dynamic>;
     } else {
       throw PickException(
-          "value $value of type ${value.runtimeType} at location ${_location()} can't be casted to Map<String, dynamic>");
+          "value $value of type ${value.runtimeType} at location ${_location()} can't be casted to Map<$K, dynamic>");
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deep_pick
 description: A library to access deep nested values inside of dart data structures, like returned from `dynamic jsonDecode(String source)`.
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/passsy/deep_pick
 author: Pascal Welsch <pascal.welsch@gmail.com>
 

--- a/test/parsing_test.dart
+++ b/test/parsing_test.dart
@@ -29,12 +29,17 @@ void main() {
     });
     test("asMap()", () {
       expect(_picked({"ab": "cd"}).asMap(), {"ab": "cd"});
+      expect(_picked({"ab": "cd"}).asMap<String>(), {"ab": "cd"});
       expect(
-          () => _picked("Bubblegum").asMap(),
+          () => _picked({"ab": "cd"}).asMap<int>(),
           throwsA(pickException(
-              containing: ["Bubblegum", "String", "Map<String, dynamic>"])));
+              containing: ["{ab: cd}", "String", "Map<int, dynamic>"])));
       expect(
-          () => _nullPick().asMap(),
+          () => _picked("Bubblegum").asMap<int>(),
+          throwsA(pickException(
+              containing: ["Bubblegum", "String", "Map<int, dynamic>"])));
+      expect(
+          () => _nullPick().asMap<String>(),
           throwsA(pickException(
               containing: ["unknownKey", "null", "Map<String, dynamic>"])));
     });


### PR DESCRIPTION
allows parsing maps with non `String` keys.

**Breaking change**