### PR TITLE
Use correct path when json is null

### DIFF
--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -4,7 +4,7 @@
 /// - a [String] to pick values from a [Map]
 /// - or [int] when you want to pick a value at index from a [List]
 Pick pick(
-  dynamic json, [
+  /*Map?|List?*/ dynamic json, [
   dynamic arg0,
   dynamic arg1,
   dynamic arg2,
@@ -16,12 +16,15 @@ Pick pick(
   dynamic arg8,
   dynamic arg9,
 ]) {
-  if (json == null) return Pick(null, const []);
   final selectors =
       <dynamic>[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]
           // null is a sign for unused "varargs"
           .where((dynamic it) => it != null)
           .toList(growable: false);
+
+  // no data, nothing to pick
+  if (json == null) return Pick(null, selectors);
+
   final List<dynamic> path = [];
   dynamic data = json;
   for (final selector in selectors) {

--- a/test/src/parsing_test.dart
+++ b/test/src/parsing_test.dart
@@ -247,6 +247,12 @@ void main() {
       final data = {"name": "John Snow"};
       expect(pick(data, 'birthday').value, isNull);
     });
+
+    test("pick from null returns null Pick with full location", () {
+      final p = pick(null, 'some', 'path');
+      expect(p.path, ['some', 'path']);
+      expect(p.value, null);
+    });
   });
 }
 


### PR DESCRIPTION
`pick(null, 'some', 'path')` now returns a Pick with the correct path.

Before the path was empty which did not indicate what was missing