### PR TITLE
Default values

### DIFF
--- a/lib/src/let.dart
+++ b/lib/src/let.dart
@@ -42,4 +42,8 @@ extension NullableLet on Pick {
     if (value == null) return null;
     return block(required());
   }
+
+  R letOrDefault<R>(R defaultValue, R Function(RequiredPick pick) block) {
+    return letOrNull(block) ?? defaultValue;
+  }
 }

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -61,4 +61,8 @@ extension NullableDateTimePick on Pick {
       return null;
     }
   }
+
+  DateTime asDateTimeOrDefault(DateTime defaultValue) {
+    return asDateTimeOrNull() ?? defaultValue;
+  }
 }

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -39,4 +39,8 @@ extension NullableDoublePick on Pick {
       return null;
     }
   }
+
+  double asDoubleOrDefault(double defaultValue) {
+    return asDoubleOrNull() ?? defaultValue;
+  }
 }

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -39,4 +39,8 @@ extension NullableIntPick on Pick {
       return null;
     }
   }
+
+  int asIntOrDefault(int defaultValue) {
+    return asIntOrNull() ?? defaultValue;
+  }
 }

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -49,4 +49,8 @@ extension NullableListPick on Pick {
       return null;
     }
   }
+
+  List<T> asListOrDefault<T>(List<T> defaultValue, [T Function(Pick) map]) {
+    return asListOrNull(map) ?? defaultValue;
+  }
 }

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -43,4 +43,8 @@ extension NullableMapPick on Pick {
       return null;
     }
   }
+
+  Map<RK, RV> asMapOrDefault<RK, RV>(Map<RK, RV> defaultValue) {
+    return asMapOrNull() ?? defaultValue;
+  }
 }

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -38,4 +38,8 @@ extension NullableStringPick on Pick {
       return null;
     }
   }
+
+  String asStringOrDefault(String defaultValue) {
+    return asStringOrNull() ?? defaultValue;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,5 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dev_dependencies:
-  test: ^1.6.0
-  lint: ^0.2.0
+  test: ^1.9.4
+  lint: ^1.1.0

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -55,6 +55,11 @@ void main() {
       expect(nullPick().asStringOrNull(), isNull);
     });
 
+    test("asStringOrDefault()", () {
+      expect(picked("adam").asStringOrDefault("eva"), "adam");
+      expect(nullPick().asStringOrDefault("eva"), "eva");
+    });
+
     test("asMapOrNull()", () {
       expect(picked({"ab": "cd"}).asMapOrNull(), {"ab": "cd"});
       expect(nullPick().asMapOrNull(), isNull);
@@ -66,6 +71,12 @@ void main() {
       expect(nullPick().asMapOrEmpty(), {});
     });
 
+    test("asMapOrDefault()", () {
+      expect(picked({"ab": "cd"}).asMapOrDefault({"foo": "bar"}), {"ab": "cd"});
+      expect(picked("a").asMapOrDefault({"foo": "bar"}), {"foo": "bar"});
+      expect(nullPick().asMapOrDefault({"foo": "bar"}), {"foo": "bar"});
+    });
+
     test("asListOrNull()", () {
       expect(picked([1, 2, 3]).asListOrNull<int>(), [1, 2, 3]);
       expect(nullPick().asListOrNull<int>(), isNull);
@@ -75,6 +86,12 @@ void main() {
       expect(picked([1, 2, 3]).asListOrEmpty<int>(), [1, 2, 3]);
       expect(picked("a").asListOrEmpty<int>(), []);
       expect(nullPick().asListOrEmpty<int>(), []);
+    });
+
+    test("asListOrDefault()", () {
+      expect(picked([1, 2, 3]).asListOrDefault<int>([8, 9]), [1, 2, 3]);
+      expect(picked("a").asListOrDefault<int>([8, 9]), [8, 9]);
+      expect(nullPick().asListOrDefault<int>([8, 9]), [8, 9]);
     });
 
     test("asBoolOrNull()", () {
@@ -99,12 +116,25 @@ void main() {
       expect(nullPick().asIntOrNull(), isNull);
     });
 
+    test("asIntOrDefault()", () {
+      expect(picked(1).asIntOrDefault(9), 1);
+      expect(nullPick().asIntOrDefault(9), 9);
+    });
+
     test("asDoubleOrNull()", () {
       expect(picked(1).asDoubleOrNull(), 1.0);
       expect(picked(2.0).asDoubleOrNull(), 2.0);
       expect(picked("3.0").asDoubleOrNull(), 3.0);
       expect(picked("a").asDoubleOrNull(), isNull);
       expect(nullPick().asDoubleOrNull(), isNull);
+    });
+
+    test("asDoubleOrDefault()", () {
+      expect(picked(1).asDoubleOrDefault(9.0), 1.0);
+      expect(picked(2.0).asDoubleOrDefault(9.0), 2.0);
+      expect(picked("3.0").asDoubleOrDefault(9.0), 3.0);
+      expect(picked("a").asDoubleOrDefault(9.0), 9.0);
+      expect(nullPick().asDoubleOrDefault(9.0), 9.0);
     });
 
     test("asDateTimeOrNull()", () {
@@ -115,6 +145,18 @@ void main() {
       expect(nullPick().asDateTimeOrNull(), isNull);
     });
 
+    test("asDateTimeOrDefault()", () {
+      final defaultValue = DateTime.utc(2020, 10, 20);
+      expect(
+          picked("2012-02-27 13:27:00,123456z")
+              .asDateTimeOrDefault(defaultValue),
+          DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
+      expect(picked("1").asDateTimeOrDefault(defaultValue), defaultValue);
+      expect(
+          picked("Bubblegum").asDateTimeOrDefault(defaultValue), defaultValue);
+      expect(nullPick().asDateTimeOrDefault(defaultValue), defaultValue);
+    });
+
     test("letOrNull()", () {
       expect(
           picked({"name": "John Snow"})
@@ -122,6 +164,18 @@ void main() {
           Person(name: "John Snow"));
       expect(
           nullPick().letOrNull((pick) => Person.fromJson(pick.asMap())), null);
+    });
+
+    test("letOrDefault()", () {
+      final defaultValue = Person(name: "Arya Stark");
+      expect(
+          picked({"name": "John Snow"}).letOrDefault(
+              defaultValue, (pick) => Person.fromJson(pick.asMap())),
+          Person(name: "John Snow"));
+      expect(
+          nullPick().letOrDefault(
+              defaultValue, (pick) => Person.fromJson(pick.asMap())),
+          defaultValue);
     });
 
     test("asListOrEmpty(Pick -> T)", () {
@@ -152,6 +206,31 @@ void main() {
           picked([]).asListOrNull((pick) => Person.fromJson(pick.asMap())), []);
       expect(nullPick().asListOrNull((pick) => Person.fromJson(pick.asMap())),
           null);
+    });
+
+    test("asListOrDefault(Pick -> T)", () {
+      final data = [
+        {"name": "John Snow"},
+        {"name": "Daenerys Targaryen"},
+      ];
+      final defaultValue = [
+        Person(name: "Arya Stark"),
+      ];
+      expect(
+          picked(data).asListOrDefault(
+              defaultValue, (pick) => Person.fromJson(pick.required().asMap())),
+          [
+            Person(name: "John Snow"),
+            Person(name: "Daenerys Targaryen"),
+          ]);
+      expect(
+          picked([]).asListOrDefault(
+              defaultValue, (pick) => Person.fromJson(pick.required().asMap())),
+          []);
+      expect(
+          nullPick().asListOrDefault(
+              defaultValue, (pick) => Person.fromJson(pick.required().asMap())),
+          defaultValue);
     });
   });
 

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -183,12 +183,21 @@ void main() {
         {"name": "John Snow"},
         {"name": "Daenerys Targaryen"},
       ];
-      expect(picked(data).asListOrEmpty((it) => Person.fromJson(it.asMap())), [
-        Person(name: "John Snow"),
-        Person(name: "Daenerys Targaryen"),
-      ]);
-      expect(picked([]).asList((pick) => Person.fromJson(pick.asMap())), []);
-      expect(nullPick().asListOrEmpty((pick) => Person.fromJson(pick.asMap())),
+      expect(
+          picked(data)
+              .asListOrEmpty((it) => Person.fromJson(it.required().asMap())),
+          [
+            Person(name: "John Snow"),
+            Person(name: "Daenerys Targaryen"),
+          ]);
+      expect(
+          picked([])
+              .required()
+              .asList((pick) => Person.fromJson(pick.required().asMap())),
+          []);
+      expect(
+          nullPick().asListOrEmpty(
+              (pick) => Person.fromJson(pick.required().asMap())),
           []);
     });
 
@@ -198,13 +207,19 @@ void main() {
         {"name": "Daenerys Targaryen"},
       ];
       expect(
-          picked(data).asListOrNull((pick) => Person.fromJson(pick.asMap())), [
-        Person(name: "John Snow"),
-        Person(name: "Daenerys Targaryen"),
-      ]);
+          picked(data)
+              .asListOrNull((pick) => Person.fromJson(pick.required().asMap())),
+          [
+            Person(name: "John Snow"),
+            Person(name: "Daenerys Targaryen"),
+          ]);
       expect(
-          picked([]).asListOrNull((pick) => Person.fromJson(pick.asMap())), []);
-      expect(nullPick().asListOrNull((pick) => Person.fromJson(pick.asMap())),
+          picked([])
+              .asListOrNull((pick) => Person.fromJson(pick.required().asMap())),
+          []);
+      expect(
+          nullPick()
+              .asListOrNull((pick) => Person.fromJson(pick.required().asMap())),
           null);
     });
 


### PR DESCRIPTION
I've implemented #8.

I've seen that there are two functions for boolean `asBoolOrTrue` and `asBoolOrFalse` not sure if we should create one consistent function `asBoolOrDefault`. 
I left it as it is now.

TODOs:
[ ] Consider `asBoolOrDefault` over `asBoolOrTrue`/`asBoolOrFalse`
[ ] Document `asDefault` syntax in README.md
[ ] Update version and Changelog