### PR TITLE
Report asListOrNull mapping errors

### DIFF
--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -34,19 +34,13 @@ extension NullableListPick on Pick {
 
   List<T> asListOrEmpty<T>([T Function(Pick) map]) {
     if (value == null) return <T>[];
-    try {
-      return required().asList(map);
-    } catch (_) {
-      return <T>[];
-    }
+    if (value is! List) return <T>[];
+    return required().asList(map);
   }
 
   List<T> /*?*/ asListOrNull<T>([T Function(Pick) map]) {
     if (value == null) return null;
-    try {
-      return required().asList(map);
-    } catch (_) {
-      return null;
-    }
+    if (value is! List) return null;
+    return required().asList(map);
   }
 }


### PR DESCRIPTION
The default value (`[]` or `null`) should only be returned when the the current value is `null` or not a `List`. Failing when mapping items should be reported.

Before the implementation always swallowed all errors and returned the default value. 

Fixes issue for `asListOrNull` and `asListOrEmpty`.
