### PR TITLE
Check the type when parsing maps

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: ["2.7", "2.8", "2.9", "dev"]
 
@@ -23,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: google/dart:latest
+      image: google/dart:dev
 
     steps:
     - uses: actions/checkout@v1
@@ -36,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: google/dart:latest
+      image: google/dart:dev
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -5,9 +5,12 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        version: ["2.7", "2.8", "2.9", "dev"]
+
     container:
-      image:  google/dart:2.7
+      image: google/dart:${{ matrix.version }}
     
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image:  google/dart:2.7
+      image: google/dart:latest
 
     steps:
     - uses: actions/checkout@v1
@@ -33,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image:  google/dart:2.7
+      image: google/dart:latest
 
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3
+
+- Fix error reporting for `asMapOr[Empty|Null]` and don't swallow parsing errors
+- Throw Map cast errors when parsing, not lazily when accessing the data
+
 ## 0.4.2
 
 - Fix error reporting of `asListOrNull(mapToUser)` and `asListOrEmpty(mapToUser)`. Both now return errors during mapping and don't swallow them

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -3,7 +3,10 @@ import 'package:deep_pick/src/pick.dart';
 extension MapPick on RequiredPick {
   Map<RK, RV> asMap<RK, RV>() {
     if (value is Map) {
-      return (value as Map<dynamic, dynamic>).cast();
+      final Map<RK, RV> view = (value as Map<dynamic, dynamic>).cast();
+      // create copy of casted view so all items are type checked here
+      // and not lazily type checked when accessing them
+      return Map.of(view);
     } else {
       throw PickException(
           "value $value of type ${value.runtimeType} at location ${location()} can't be casted to Map<dynamic, dynamic>");
@@ -27,20 +30,13 @@ extension NullableMapPick on Pick {
 
   Map<RK, RV> asMapOrEmpty<RK, RV>() {
     if (value == null) return <RK, RV>{};
-
-    try {
-      return required().asMap();
-    } catch (_) {
-      return <RK, RV>{};
-    }
+    if (value is! Map) return <RK, RV>{};
+    return required().asMap();
   }
 
   Map<RK, RV> /*?*/ asMapOrNull<RK, RV>() {
     if (value == null) return null;
-    try {
-      return required().asMap();
-    } catch (_) {
-      return null;
-    }
+    if (value is! Map) return null;
+    return required().asMap();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deep_pick
 description: A library to access deep nested values inside of dart data structures, like returned from `dynamic jsonDecode(String source)`.
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/passsy/deep_pick
 
 environment:

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -65,10 +65,56 @@ void main() {
       expect(nullPick().asMapOrNull(), isNull);
     });
 
+    test("asMapOrNull() reports errors correctly", () {
+      final dynamic data = {
+        "a": {"some": "value"}
+      };
+
+      try {
+        final Map<String, bool> parsed = picked(data).asMapOrNull();
+        fail("casted map without verifying the types. "
+            "Expected Map<String, bool> but was ${parsed.runtimeType}");
+        // ignore: avoid_catching_errors
+      } on TypeError catch (e, stack) {
+        expect(
+          e,
+          const TypeMatcher<TypeError>().having(
+            (e) => e.toString(),
+            'message',
+            stringContainsInOrder(
+                ["<String, String>", "is not a subtype of type", "bool"]),
+          ),
+        );
+      }
+    });
+
     test("asMapOrEmpty()", () {
       expect(picked({"ab": "cd"}).asMapOrEmpty(), {"ab": "cd"});
       expect(picked("a").asMapOrEmpty(), {});
       expect(nullPick().asMapOrEmpty(), {});
+    });
+
+    test("asMapOrEmpty() reports errors correctly", () {
+      final dynamic data = {
+        "a": {"some": "value"}
+      };
+
+      try {
+        final Map<String, bool> parsed = picked(data).asMapOrEmpty();
+        fail("casted map without verifying the types. "
+            "Expected Map<String, bool> but was ${parsed.runtimeType}");
+        // ignore: avoid_catching_errors
+      } on TypeError catch (e, stack) {
+        expect(
+          e,
+          const TypeMatcher<TypeError>().having(
+            (e) => e.toString(),
+            'message',
+            stringContainsInOrder(
+                ["<String, String>", "is not a subtype of type", "bool"]),
+          ),
+        );
+      }
     });
 
     test("asListOrNull()", () {

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -75,10 +75,23 @@ void main() {
         fail("casted map without verifying the types. "
             "Expected Map<String, bool> but was ${parsed.runtimeType}");
         // ignore: avoid_catching_errors
-      } on TypeError catch (e, stack) {
+      } on TypeError catch (e) {
         expect(
           e,
           const TypeMatcher<TypeError>().having(
+            (e) => e.toString(),
+            'message',
+            stringContainsInOrder(
+                ["<String, String>", "is not a subtype of type", "bool"]),
+          ),
+        );
+        // ignore: avoid_catching_errors
+      } on CastError catch (e) {
+        // backwards compatibility for Dart 2.7
+        // CastError was replaced with TypeError in Dart 2.8
+        expect(
+          e,
+          const TypeMatcher<CastError>().having(
             (e) => e.toString(),
             'message',
             stringContainsInOrder(
@@ -104,10 +117,23 @@ void main() {
         fail("casted map without verifying the types. "
             "Expected Map<String, bool> but was ${parsed.runtimeType}");
         // ignore: avoid_catching_errors
-      } on TypeError catch (e, stack) {
+      } on TypeError catch (e) {
         expect(
           e,
           const TypeMatcher<TypeError>().having(
+            (e) => e.toString(),
+            'message',
+            stringContainsInOrder(
+                ["<String, String>", "is not a subtype of type", "bool"]),
+          ),
+        );
+        // ignore: avoid_catching_errors
+      } on CastError catch (e) {
+        // backwards compatibility for Dart 2.7
+        // CastError was replaced with TypeError in Dart 2.8
+        expect(
+          e,
+          const TypeMatcher<CastError>().having(
             (e) => e.toString(),
             'message',
             stringContainsInOrder(

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -64,6 +64,29 @@ void main() {
               containing: ["unknownKey", "null", "Map<dynamic, dynamic>"])));
     });
 
+    test("asMap() throws for cast error", () {
+      final dynamic data = {
+        "a": {"some": "value"}
+      };
+
+      try {
+        final Map<String, bool> parsed = picked(data).asMap();
+        fail("casted map without verifying the types. "
+            "Expected Map<String, bool> but was ${parsed.runtimeType}");
+        // ignore: avoid_catching_errors
+      } on TypeError catch (e, stack) {
+        expect(
+          e,
+          const TypeMatcher<TypeError>().having(
+            (e) => e.toString(),
+            'message',
+            stringContainsInOrder(
+                ["<String, String>", "is not a subtype of type", "bool"]),
+          ),
+        );
+      }
+    });
+
     test("asList()", () {
       expect(picked(["a", "b", "c"]).asList(), ["a", "b", "c"]);
       expect(picked([1, 2, 3]).asList<int>(), [1, 2, 3]);

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -74,10 +74,23 @@ void main() {
         fail("casted map without verifying the types. "
             "Expected Map<String, bool> but was ${parsed.runtimeType}");
         // ignore: avoid_catching_errors
-      } on TypeError catch (e, stack) {
+      } on TypeError catch (e) {
         expect(
           e,
           const TypeMatcher<TypeError>().having(
+            (e) => e.toString(),
+            'message',
+            stringContainsInOrder(
+                ["<String, String>", "is not a subtype of type", "bool"]),
+          ),
+        );
+        // ignore: avoid_catching_errors
+      } on CastError catch (e) {
+        // backwards compatibility for Dart 2.7
+        // CastError was replaced with TypeError in Dart 2.8
+        expect(
+          e,
+          const TypeMatcher<CastError>().having(
             (e) => e.toString(),
             'message',
             stringContainsInOrder(


### PR DESCRIPTION
- Check the type when parsing maps in place, not lazily
- Return correct errors for `asMapOr[Empty|Null]` and don't bluntly return the fallback (Similar to `asListOr[Empty|Null]`)