### PR TITLE
Context API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and `context` has been added.
 + RequiredPick(this.value, {this.path = const [], Map<String, dynamic> context})
 ```
 
+- The `path` is now correctly forwarded after `Pick#call` or `Pick#asListOrEmpty` and always shows the full path since origin 
+
 ## 0.4.3
 
 - Fix error reporting for `asMapOr[Empty|Null]` and don't swallow parsing errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 0.5.0
+
+- New context API. You can now attach relevant additional information for parsing directly to the `Pick` object. This allows passing information into `fromPick` constructors without adding new parameters to all constructors in between.
+
+```dart
+// Add context
+final shoes = pick(json, 'shoes')
+    .addContext('apiVersion', "2.3.0")
+    .addContext('lang', "en-US")
+    .asListOrEmpty((p) => Shoe.fromPick(p.required()));
+``` 
+
+```dart
+import 'package:version/version.dart';
+
+// Read context
+factory Shoe.fromPick(RequiredPick pick) {
+  // read context API
+  final version = pick.fromContext('newApi').required().let((pick) => Version(pick.asString()));
+  return Shoe(
+    id: pick('id').required().asString(),
+    name: pick('name').required().asString(),
+    // manufacturer is a required field in the new API
+    manufacturer: version >= Version(2, 3, 0)
+        ? pick('manufacturer').required().asString()
+        : pick('manufacturer').asStringOrNull(),
+    tags: pick('tags').asListOrEmpty(),
+  );
+}
+```
+- Breaking: `Pick` and `RequiredPick` have chained their constructor signature. `path` is now a named argument 
+and `context` has been added.
+
+```diff
+- RequiredPick(this.value, [this.path = const []])
++ RequiredPick(this.value, {this.path = const [], Map<String, dynamic> context})
+```
+
 ## 0.4.3
 
 - Fix error reporting for `asMapOr[Empty|Null]` and don't swallow parsing errors

--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -10,6 +10,7 @@ void main() {
      { 
        "id": "421",
        "name": "Nike Zoom Fly 3",
+       "manufacturer": "nike",
        "tags": ["nike", "JustDoIt"]
      },
      { 
@@ -64,6 +65,12 @@ void main() {
   //   Shoe{id: 421, name: Nike Zoom Fly 3, tags: [nike, JustDoIt]},
   //   Shoe{id: 532, name: adidas Ultraboost, tags: [adidas, ImpossibleIsNothing]}
   // ]
+
+  // Use the Context API to pass contextual information down to parsing
+  // without adding new arguments
+  final newShoes = (pick(json, 'shoes')..context['newApi'] = true)
+      .asListOrEmpty((p) => Shoe.fromPick(p.required()));
+  print(newShoes);
 }
 
 /// A data class representing a shoe model
@@ -80,10 +87,15 @@ class Shoe {
         assert(tags != null);
 
   factory Shoe.fromPick(RequiredPick pick) {
+    // read context API
+    final newApi = pick.context.containsKey('newApi');
     return Shoe(
       id: pick('id').required().asString(),
       name: pick('name').required().asString(),
-      manufacturer: pick('manufacturer').asStringOrNull(),
+      // manufacturer is a required field in the new API
+      manufacturer: newApi
+          ? pick('manufacturer').required().asString()
+          : pick('manufacturer').asStringOrNull(),
       tags: pick('tags').asListOrEmpty(),
     );
   }

--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -68,7 +68,8 @@ void main() {
 
   // Use the Context API to pass contextual information down to parsing
   // without adding new arguments
-  final newShoes = (pick(json, 'shoes')..context['newApi'] = true)
+  final newShoes = pick(json, 'shoes')
+      .addContext('newApi', true)
       .asListOrEmpty((p) => Shoe.fromPick(p.required()));
   print(newShoes);
 }
@@ -88,7 +89,7 @@ class Shoe {
 
   factory Shoe.fromPick(RequiredPick pick) {
     // read context API
-    final newApi = pick.context.containsKey('newApi');
+    final newApi = pick.fromContext('newApi').asBoolOrFalse();
     return Shoe(
       id: pick('id').required().asString(),
       name: pick('name').required().asString(),

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -141,7 +141,7 @@ class PickException implements Exception {
 
   @override
   String toString() {
-    return 'PickException{message: $message}';
+    return 'PickException($message)';
   }
 }
 

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -163,7 +163,7 @@ class RequiredPick with PickLocation, PickContext<RequiredPick> {
   }
 
   @override
-  Map<String, dynamic> get context => _context ?? const {};
+  Map<String, dynamic> get context => _context;
   final Map<String, dynamic> _context;
 
   @override

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -8,7 +8,7 @@ extension ListPick on RequiredPick {
       } else {
         var i = 0;
         return (value as List<dynamic>)
-            .map((it) => map(Pick(it, [...path, i++])))
+            .map((it) => map(Pick(it, path: [...path, i++], context: context)))
             .toList(growable: false);
       }
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deep_pick
 description: A library to access deep nested values inside of dart data structures, like returned from `dynamic jsonDecode(String source)`.
-version: 0.4.3
+version: 0.5.0
 homepage: https://github.com/passsy/deep_pick
 
 environment:

--- a/test/src/deprecated_parse_methods_test.dart
+++ b/test/src/deprecated_parse_methods_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('parse objects', () {
-    test('prase json object 3 levels deep', () {
+    test('parse json object 3 levels deep', () {
       final json = {
         'level1': {
           'level2': {

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -317,6 +317,15 @@ void main() {
       expect(root.context, {'lang': 'de'});
     });
 
+    test('add and read from context with syntax sugar', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+      final root = pick(data).addContext('lang', 'de');
+      expect(root.fromContext('lang').asMapOrNull(), {'lang': 'de'});
+    });
+
     test('copy into required()', () {
       final data = [
         {'name': 'John Snow'},

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -11,7 +11,7 @@ void main() {
     });
 
     test('toString() works as expected', () {
-      expect(RequiredPick('a', ['b', 0]).toString(),
+      expect(RequiredPick('a', path: ['b', 0]).toString(),
           'RequiredPick(value=a, path=[b, 0])');
     });
 
@@ -50,6 +50,32 @@ void main() {
             'not a List or Map',
             '{a: b}'
           ])));
+    });
+
+    test('call()', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+
+      final RequiredPick picked = pick(data, 0).required();
+      expect(picked.value, {'name': 'John Snow'});
+
+      // pick further
+      expect(picked.call('name').required().asString(), 'John Snow');
+    });
+
+    test('call() carries over the location for good stacktraces', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+
+      final RequiredPick level1Pick = pick(data, 0).required();
+      expect(level1Pick.path, [0]);
+
+      final level2Pick = level1Pick.call('name');
+      expect(level2Pick.path, [0, 'name']);
     });
 
     test('asMap()', () {

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -219,4 +219,58 @@ void main() {
           throwsA(pickException(containing: ['unknownKey', 'null', 'List'])));
     });
   });
+
+  group('context API', () {
+    test('add and read from context', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+      final root = pick(data).required();
+      root.context['lang'] = 'de';
+      expect(root.context, {'lang': 'de'});
+    });
+
+    test('add and read from context with syntax sugar', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+      final root = pick(data).required().addContext('lang', 'de');
+      expect(root.fromContext('lang').asMapOrNull(), {'lang': 'de'});
+    });
+
+    test('copy into asList()', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+      final root = pick(data).required();
+      root.context['lang'] = 'de';
+      expect(root.context, {'lang': 'de'});
+
+      final contexts = root.asList((pick) => pick.context);
+      expect(contexts, [
+        {'lang': 'de'},
+        {'lang': 'de'}
+      ]);
+    });
+
+    test('copy into call() pick', () {
+      final data = [
+        {'name': 'John Snow'},
+        {'name': 'Daenerys Targaryen'},
+      ];
+      final root = pick(data).required();
+      root.context['lang'] = 'de';
+      expect(root.context, {'lang': 'de'});
+
+      final afterCall = root.call(1, 'name').required();
+      expect(afterCall.context, {'lang': 'de'});
+
+      root.context['hello'] = 'world';
+      expect(root.context, {'lang': 'de', 'hello': 'world'});
+      expect(afterCall.context, {'lang': 'de'});
+    });
+  });
 }

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -58,7 +58,7 @@ void main() {
         {'name': 'Daenerys Targaryen'},
       ];
 
-      final RequiredPick picked = pick(data, 0).required();
+      final picked = pick(data, 0).required();
       expect(picked.value, {'name': 'John Snow'});
 
       // pick further
@@ -71,7 +71,7 @@ void main() {
         {'name': 'Daenerys Targaryen'},
       ];
 
-      final RequiredPick level1Pick = pick(data, 0).required();
+      final level1Pick = pick(data, 0).required();
       expect(level1Pick.path, [0]);
 
       final level2Pick = level1Pick.call('name');


### PR DESCRIPTION
- New context API. You can now attach relevant additional information for parsing directly to the `Pick` object. This allows passing information into `fromPick` constructors without adding new parameters to all constructors in between.

```dart
// Add context
final shoes = pick(json, 'shoes')
    .addContext('apiVersion', "2.3.0")
    .addContext('lang', "en-US")
    .asListOrEmpty((p) => Shoe.fromPick(p.required()));
``` 

```dart
import 'package:version/version.dart';

// Read context
factory Shoe.fromPick(RequiredPick pick) {
  // read context API
  final version = pick.fromContext('newApi').required().let((pick) => Version(pick.asString()));
  return Shoe(
    id: pick('id').required().asString(),
    name: pick('name').required().asString(),
    // manufacturer is a required field in the new API
    manufacturer: version >= Version(2, 3, 0)
        ? pick('manufacturer').required().asString()
        : pick('manufacturer').asStringOrNull(),
    tags: pick('tags').asListOrEmpty(),
  );
}
```
- Breaking: `Pick` and `RequiredPick` have chained their constructor signature. `path` is now a named argument 
and `context` has been added.

```diff
- RequiredPick(this.value, [this.path = const []])
+ RequiredPick(this.value, {this.path = const [], Map<String, dynamic> context})
```