### PR TITLE
Example omitting unnecessary type casts

### DIFF
--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -15,11 +15,12 @@ extension DateTimePick on RequiredPick {
   /// - `'-123450101 00:00:00 Z'`: in the year -12345.
   /// - `'2002-02-27T14:00:00-0500'`: Same as `'2002-02-27T19:00:00Z'`
   DateTime asDateTime() {
+    final value = this.value;
     if (value is DateTime) {
-      return value as DateTime;
+      return value;
     }
     if (value is String) {
-      final dateTime = DateTime.tryParse(value as String);
+      final dateTime = DateTime.tryParse(value);
       if (dateTime != null) {
         return dateTime;
       }

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -2,14 +2,15 @@ import 'package:deep_pick/src/pick.dart';
 
 extension DoublePick on RequiredPick {
   double asDouble() {
+    final value = this.value;
     if (value is double) {
-      return value as double;
+      return value;
     }
     if (value is num) {
-      return (value as num).toDouble();
+      return value.toDouble();
     }
     if (value is String) {
-      final parsed = double.tryParse(value as String);
+      final parsed = double.tryParse(value);
       if (parsed != null) {
         return parsed;
       }


### PR DESCRIPTION
@passsy Elaborating on my comment here: https://github.com/passsy/deep_pick/commit/ac3c9e0a4c784f7da7fa53760ffa6be5bec0d672#r44458494

The reason you need to do `final value = this.value` is because instance fields can be overriden, which is why flow analysis does not work with instance fields. Hence, you need the local variable to get the analyzer to do the cast for you :)