### PR TITLE
Remove additional type cast

### DIFF
--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -107,10 +107,11 @@ class Pick with PickLocation, PickContext<Pick> {
   ///
   /// Crashes when the the value is `null`.
   RequiredPick required() {
+    final value = this.value;
     if (value == null) {
       throw PickException('required value at location ${location()} is null');
     }
-    return RequiredPick(value!, path: path, context: _context);
+    return RequiredPick(value, path: path, context: _context);
   }
 
   @override

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -2,8 +2,9 @@ import 'package:deep_pick/src/pick.dart';
 
 extension BoolPick on RequiredPick {
   bool asBool() {
+    final value = this.value;
     if (value is bool) {
-      return value as bool;
+      return value;
     }
     if (value is String) {
       if (value == 'true') return true;

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -9,14 +9,15 @@ extension IntPick on RequiredPick {
   /// - [double] is gets converted to [int] via [num.toInt()]
   /// {@endtemplate}
   int asInt() {
+    final value = this.value;
     if (value is int) {
-      return value as int;
+      return value;
     }
     if (value is num) {
-      return (value as num).toInt();
+      return value.toInt();
     }
     if (value is String) {
-      final parsed = int.tryParse(value as String);
+      final parsed = int.tryParse(value);
       if (parsed != null) {
         return parsed;
       }

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -2,12 +2,13 @@ import 'package:deep_pick/src/pick.dart';
 
 extension ListPick on RequiredPick {
   List<T> asList<T>([T Function(Pick)? map]) {
+    final value = this.value;
     if (value is List) {
       if (map == null) {
-        return (value as List<dynamic>).cast<T>();
+        return value.cast<T>();
       }
       var i = 0;
-      return (value as List<dynamic>)
+      return value
           .map((it) => map(Pick(it, path: [...path, i++], context: context)))
           .toList(growable: false);
     }

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -2,8 +2,9 @@ import 'package:deep_pick/src/pick.dart';
 
 extension MapPick on RequiredPick {
   Map<RK, RV> asMap<RK, RV>() {
+    final value = this.value;
     if (value is Map) {
-      final view = (value as Map<dynamic, dynamic>).cast<RK, RV>();
+      final view = value.cast<RK, RV>();
       // create copy of casted view so all items are type checked here
       // and not lazily type checked when accessing them
       return Map.of(view);

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -10,8 +10,9 @@ extension StringPick on RequiredPick {
   /// values such as a [List] or [Map]
   /// {@endtemplate}
   String asString() {
+    final value = this.value;
     if (value is String) {
-      return value as String;
+      return value;
     }
     if (value is List || value is Map) {
       throw PickException(


### PR DESCRIPTION
Continues efforts made in #21 to remove unnecessary type casts in all of `deep_pick`.

Also removes the need to assume a variable is not null:
`value!` -> `value`