### PR TITLE
Differentiate between `null` and an absent value

### DIFF
--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -17,7 +17,8 @@ void main() {
        "id": "532",
        "name": "adidas Ultraboost",
        "manufacturer": "adidas",
-       "tags": ["adidas", "ImpossibleIsNothing"]
+       "tags": ["adidas", "ImpossibleIsNothing"],
+       "price": null
      }
   ]
 }
@@ -72,6 +73,15 @@ void main() {
       .withContext('newApi', true)
       .asListOrEmpty((p) => Shoe.fromPick(p.required()));
   print(newShoes);
+
+  // access value out of range
+  final puma = pick(
+    json,
+    'shoes',
+    1,
+  );
+  print(puma.isAbsent()); // true;
+  print(puma.value); // null
 }
 
 /// A data class representing a shoe model
@@ -83,11 +93,13 @@ class Shoe {
     required this.name,
     this.manufacturer,
     required this.tags,
+    required this.price,
   });
 
   factory Shoe.fromPick(RequiredPick pick) {
     // read context API
     final newApi = pick.fromContext('newApi').asBoolOrFalse();
+    final pricePick = pick('price');
     return Shoe(
       id: pick('id').required().asString(),
       name: pick('name').required().asString(),
@@ -96,6 +108,11 @@ class Shoe {
           ? pick('manufacturer').required().asString()
           : pick('manufacturer').asStringOrNull(),
       tags: pick('tags').asListOrEmpty(),
+      price: () {
+        // when server doesn't send the price field the shoe is not available
+        if (pricePick.isAbsent()) return 'Not for sale';
+        return pricePick.asStringOrNull() ?? 'Price available soon';
+      }(),
     );
   }
 
@@ -111,9 +128,12 @@ class Shoe {
   /// never null, falls back to empty list
   final List<String> tags;
 
+  /// what to display as price
+  final String price;
+
   @override
   String toString() {
-    return 'Shoe{id: $id, name: $name, tags: $tags}';
+    return 'Shoe{id: $id, name: "$name", price: "$price", tags: $tags}';
   }
 
   @override

--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -75,11 +75,7 @@ void main() {
   print(newShoes);
 
   // access value out of range
-  final puma = pick(
-    json,
-    'shoes',
-    1,
-  );
+  final puma = pick(json, 'shoes', 1);
   print(puma.isAbsent()); // true;
   print(puma.value); // null
 }

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -27,9 +27,6 @@ Pick pick(
 Pick _drillDown(dynamic json, List<dynamic> selectors,
     {List<dynamic> parentPath = const [], Map<String, dynamic>? context}) {
   final newPath = [...parentPath, ...selectors];
-  // no data, nothing to pick
-  if (json == null) return Pick(null, path: newPath, context: context);
-
   final path = <dynamic>[];
   dynamic data = json;
   for (final selector in selectors) {
@@ -43,15 +40,16 @@ Pick _drillDown(dynamic json, List<dynamic> selectors,
           }
           // found a value, continue drill down
           continue;
+          // ignore: avoid_catching_errors
         } on RangeError catch (_) {
           // out of range, value not found at index selector
-          return Pick.absent(path.length, path: newPath, context: context);
+          return Pick.absent(path.length - 1, path: newPath, context: context);
         }
       }
     }
     if (data is Map) {
       if (!data.containsKey(selector)) {
-        return Pick.absent(path.length, path: newPath, context: context);
+        return Pick.absent(path.length - 1, path: newPath, context: context);
       }
       final picked = data[selector];
       if (picked == null) {
@@ -67,7 +65,7 @@ Pick _drillDown(dynamic json, List<dynamic> selectors,
           "It's not possible to pick a value by using a index ($selector)");
     }
     // can't drill down any more to find the exact location.
-    return Pick.absent(path.length, path: newPath, context: context);
+    return Pick.absent(path.length - 1, path: newPath, context: context);
   }
   return Pick(data, path: newPath, context: context);
 }
@@ -85,7 +83,7 @@ class Pick with PickLocation, PickContext<Pick> {
     this.path = const [],
     Map<String, dynamic>? context,
   })  : _missingValueAtIndex = missingValueAtIndex,
-        _context = context != null ? Map.of(context) : {} {}
+        _context = context != null ? Map.of(context) : {};
 
   /// The picked value, might be `null`
   Object? value;

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -72,12 +72,20 @@ Pick _drillDown(dynamic json, List<dynamic> selectors,
 
 /// A picked object holding the [value] and giving access to useful parsing functions
 class Pick with PickLocation, PickContext<Pick> {
+  /// Pick constructor when being able to drill down [path] all the way to reach
+  /// the value.
+  /// [value] may still be `null` but the structure was correct, therefore
+  /// [isAbsent] will always return `false`.
   Pick(
     this.value, {
     this.path = const [],
     Map<String, dynamic>? context,
   }) : _context = context != null ? Map.of(context) : {};
 
+  /// Pick of an absent value. While drilling down [path] the structure of the
+  /// data did not match the [path] and the value wasn't found.
+  ///
+  /// [value] will always return `null` and [isAbsent] always `true`.
   Pick.absent(
     int missingValueAtIndex, {
     this.path = const [],

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -91,11 +91,11 @@ class Pick with PickLocation, PickContext<Pick> {
   /// Allows the distinction between the actual [value] `null` and the value not
   /// being available
   ///
-  /// Usually it doesn't matter, but for rare cases it does this method can be
+  /// Usually, it doesn't matter, but for rare cases, it does this method can be
   /// used to check if a [Map] contains `null` for a key or the key being absent
   ///
   /// Not available could mean:
-  /// - Accessing a key which doesn't exists in a
+  /// - Accessing a key which doesn't exist in a
   /// - Reading the value from [List] when the index is greater than the length
   /// - Trying to access a key in a [Map] but the found data structure is a [List]
   ///

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -67,21 +67,34 @@ void main() {
         final p = pick("a");
         expect(p.value, isNotNull);
         expect(p.isAbsent(), isFalse);
+        expect(p.missingValueAtIndex, null);
       });
       test('is not absent but null', () {
         final p = pick(null);
         expect(p.value, isNull);
         expect(p.isAbsent(), isFalse);
+        expect(p.missingValueAtIndex, null);
       });
       test('is not absent but null further down', () {
         final p = pick({'a': null}, 'a');
         expect(p.value, isNull);
         expect(p.isAbsent(), isFalse);
+        expect(p.missingValueAtIndex, null);
       });
       test('is not absent, not null', () {
         final p = pick({'a', 1}, 'b');
         expect(p.value, isNull);
         expect(p.isAbsent(), isTrue);
+        expect(p.missingValueAtIndex, 0);
+      });
+      test('is not absent, not null, further down', () {
+        final json = {
+          'a': {'b': 1}
+        };
+        final p = pick(json, 'a', 'x' /*absent*/);
+        expect(p.value, isNull);
+        expect(p.isAbsent(), isTrue);
+        expect(p.missingValueAtIndex, 1);
       });
     });
   });

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -61,6 +61,29 @@ void main() {
       final level2Pick = level1Pick.call('name');
       expect(level2Pick.path, [0, 'name']);
     });
+
+    group('isAbsent()', () {
+      test('is not absent because value', () {
+        final p = pick("a");
+        expect(p.value, isNotNull);
+        expect(p.isAbsent(), isFalse);
+      });
+      test('is not absent but null', () {
+        final p = pick(null);
+        expect(p.value, isNull);
+        expect(p.isAbsent(), isFalse);
+      });
+      test('is not absent but null further down', () {
+        final p = pick({'a': null}, 'a');
+        expect(p.value, isNull);
+        expect(p.isAbsent(), isFalse);
+      });
+      test('is not absent, not null', () {
+        final p = pick({'a', 1}, 'b');
+        expect(p.value, isNull);
+        expect(p.isAbsent(), isTrue);
+      });
+    });
   });
 
   group('parsing', () {
@@ -304,7 +327,7 @@ void main() {
       expect(pick(data, 'birthday').isAbsent(), true);
     });
 
-    test('documentation example Map', (){
+    test('documentation example Map', () {
       final pa = pick({"a": null}, "a");
       expect(pa.value, isNull);
       expect(pa.isAbsent(), false);
@@ -314,7 +337,7 @@ void main() {
       expect(pb.isAbsent(), true);
     });
 
-    test('documentation example List', (){
+    test('documentation example List', () {
       final p0 = pick([null], 0);
       expect(p0.value, isNull);
       expect(p0.isAbsent(), false);
@@ -324,7 +347,7 @@ void main() {
       expect(p2.isAbsent(), true);
     });
 
-    test('Map key for list', (){
+    test('Map key for list', () {
       final p = pick([], 'a');
       expect(p.value, isNull);
       expect(p.isAbsent(), true);

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -288,18 +288,46 @@ void main() {
     });
   });
 
-  group('invalid pick', () {
+  group('isAbsent', () {
     test('out of range in list returns null pick', () {
       final data = [
         {'name': 'John Snow'},
         {'name': 'Daenerys Targaryen'},
       ];
       expect(pick(data, 10).value, isNull);
+      expect(pick(data, 10).isAbsent(), true);
     });
 
     test('unknown property in map returns null', () {
       final data = {'name': 'John Snow'};
       expect(pick(data, 'birthday').value, isNull);
+      expect(pick(data, 'birthday').isAbsent(), true);
+    });
+
+    test('documentation example Map', (){
+      final pa = pick({"a": null}, "a");
+      expect(pa.value, isNull);
+      expect(pa.isAbsent(), false);
+
+      final pb = pick({"a": null}, "b");
+      expect(pb.value, isNull);
+      expect(pb.isAbsent(), true);
+    });
+
+    test('documentation example List', (){
+      final p0 = pick([null], 0);
+      expect(p0.value, isNull);
+      expect(p0.isAbsent(), false);
+
+      final p2 = pick([], 2);
+      expect(p2.value, isNull);
+      expect(p2.isAbsent(), true);
+    });
+
+    test('Map key for list', (){
+      final p = pick([], 'a');
+      expect(p.value, isNull);
+      expect(p.isAbsent(), true);
     });
   });
 


### PR DESCRIPTION
Allows the distinction between the actual value `null` and the value not being available

Usually, it doesn't matter, but for rare cases, it does this method can be used to check if a [Map] contains `null` for a key or the key being absent

Not available could mean:
- Accessing a key which doesn't exist in a
- Reading the value from [List] when the index is greater than the length
- Trying to access a key in a [Map] but the found data structure is a [List]

```dart
pick({"a": null}, "a").isAbsent(); // false
pick({"a": null}, "b").isAbsent(); // true

pick([null], 0).isAbsent(); // false
pick([], 2).isAbsent(); // true

pick([], "a").isAbsent(); // true
```