### PR TITLE
Add *OrThrow shorthand methods 

### DIFF
--- a/lib/deep_pick.dart
+++ b/lib/deep_pick.dart
@@ -1,4 +1,4 @@
-export 'package:deep_pick/src/pick.dart';
+export 'package:deep_pick/src/pick.dart' hide requiredPickErrorHintKey;
 export 'package:deep_pick/src/pick_bool.dart';
 export 'package:deep_pick/src/pick_datetime.dart';
 export 'package:deep_pick/src/pick_double.dart';

--- a/lib/deep_pick.dart
+++ b/lib/deep_pick.dart
@@ -1,9 +1,9 @@
-export 'package:deep_pick/src/let.dart';
 export 'package:deep_pick/src/pick.dart';
 export 'package:deep_pick/src/pick_bool.dart';
 export 'package:deep_pick/src/pick_datetime.dart';
 export 'package:deep_pick/src/pick_double.dart';
 export 'package:deep_pick/src/pick_int.dart';
+export 'package:deep_pick/src/pick_let.dart';
 export 'package:deep_pick/src/pick_list.dart';
 export 'package:deep_pick/src/pick_map.dart';
 export 'package:deep_pick/src/pick_string.dart';

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -158,7 +158,10 @@ class Pick with PickLocation, PickContext<Pick> {
   RequiredPick required() {
     final value = this.value;
     if (value == null) {
-      throw PickException('required value at location ${location()} is null');
+      final more = fromContext(requiredPickErrorHintKey).value as String?;
+      final moreSegment = more == null ? '' : ' $more';
+      throw PickException('required value at location ${location()} '
+          'is ${isAbsent() ? 'absent' : 'null'}.$moreSegment');
     }
     return RequiredPick(value, path: path, context: _context);
   }
@@ -215,6 +218,10 @@ class RequiredPick with PickLocation, PickContext<RequiredPick> {
   @override
   RequiredPick get _builder => this;
 }
+
+/// Used internally with [PickContext.withContext] to add additional information
+/// to the error message
+const requiredPickErrorHintKey = '_required_pick_error_hint';
 
 class PickException implements Exception {
   PickException(this.message);

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -152,9 +152,10 @@ class Pick with PickLocation, PickContext<Pick> {
   Map<String, dynamic> get context => _context;
   final Map<String, dynamic> _context;
 
-  /// Converts the picked values to a non-nullable type [RequiredPick].
+  /// Enter a "required" context which requires the picked value to be non-null
+  /// and parsable or a [PickException] is thrown.
   ///
-  /// Crashes when the the value is `null`.
+  /// Crashes when the the value is `null` or can't be parsed correctly with the asXyz() methods.
   RequiredPick required() {
     final value = this.value;
     if (value == null) {

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -16,19 +16,12 @@ extension BoolPick on RequiredPick {
 }
 
 extension NullableBoolPick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'By default values are optional and can only be converted when a fallback is provided '
-      'i.e. .asBoolOrNull() which falls back to `null`. '
-      'Use .required().asBool() in cases the value is mandatory. '
-      "It will crash when the value couldn't be picked.")
-  @Deprecated('Use .required().asBool()')
-  bool asBool() {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not an instance of bool');
-    }
+  @Deprecated('Use .asBoolOrThrow()')
+  bool Function() get asBool => asBoolOrThrow;
+
+  bool asBoolOrThrow() {
+    withContext(requiredPickErrorHintKey,
+        'Use asBoolOrNull() when the value may be null at some point (bool?).');
     return required().asBool();
   }
 

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -21,7 +21,7 @@ extension NullableBoolPick on Pick {
 
   bool asBoolOrThrow() {
     withContext(requiredPickErrorHintKey,
-        'Use asBoolOrNull() when the value may be null at some point (bool?).');
+        'Use asBoolOrNull() when the value may be null/absent at some point (bool?).');
     return required().asBool();
   }
 

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -10,8 +10,8 @@ extension BoolPick on RequiredPick {
       if (value == 'true') return true;
       if (value == 'false') return false;
     }
-    throw PickException(
-        "value $value of type ${value.runtimeType} at location ${location()} can't be casted to bool");
+    throw PickException('value $value of type ${value.runtimeType} '
+        'at location ${location()} can not be casted to bool');
   }
 }
 

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -31,18 +31,12 @@ extension DateTimePick on RequiredPick {
 }
 
 extension NullableDateTimePick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'By default values are optional and can only be converted when a fallback is provided '
-      'i.e. .asDateTimeOrNull() which falls back to `null`. '
-      'Use .required().asDateTime() in cases the value is mandatory. '
-      "It will crash when the value couldn't be picked.")
-  DateTime asDateTime() {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not an instance of DateTime');
-    }
+  @Deprecated('Use .asDateTimeOrThrow()')
+  DateTime Function() get asDateTime => asDateTimeOrThrow;
+
+  DateTime asDateTimeOrThrow() {
+    withContext(requiredPickErrorHintKey,
+        'Use asDateTimeOrNull() when the value may be null at some point (DateTime?).');
     return required().asDateTime();
   }
 

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -25,8 +25,8 @@ extension DateTimePick on RequiredPick {
         return dateTime;
       }
     }
-    throw PickException(
-        "value $value of type ${value.runtimeType} at location ${location()} can't be parsed as DateTime");
+    throw PickException('value $value of type ${value.runtimeType} '
+        'at location ${location()} can not be parsed as DateTime');
   }
 }
 

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -1,6 +1,9 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension DateTimePick on RequiredPick {
+  /// Parses the picked non-null [value] as [DateTime] or throws
+  ///
+  /// {@template Pick.asDateTime}
   /// Examples of parsable date formats:
   ///
   /// - `'2012-02-27 13:27:00'`
@@ -14,6 +17,7 @@ extension DateTimePick on RequiredPick {
   /// - `'2012-02-27T14+00:00'`
   /// - `'-123450101 00:00:00 Z'`: in the year -12345.
   /// - `'2002-02-27T14:00:00-0500'`: Same as `'2002-02-27T19:00:00Z'`
+  /// {@endtemplate}
   DateTime asDateTime() {
     final value = this.value;
     if (value is DateTime) {
@@ -34,25 +38,20 @@ extension NullableDateTimePick on Pick {
   @Deprecated('Use .asDateTimeOrThrow()')
   DateTime Function() get asDateTime => asDateTimeOrThrow;
 
+  /// Parses the picked [value] as [DateTime] or throws
+  ///
+  /// Shorthand for `.required().asDateTime()`
+  ///
+  /// {@macro Pick.asDateTime}
   DateTime asDateTimeOrThrow() {
     withContext(requiredPickErrorHintKey,
-        'Use asDateTimeOrNull() when the value may be null at some point (DateTime?).');
+        'Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).');
     return required().asDateTime();
   }
 
-  /// Examples of parsable date formats:
+  /// Parses the picked [value] as [DateTime] or returns `null`
   ///
-  /// - `'2012-02-27 13:27:00'`
-  /// - `'2012-02-27 13:27:00.123456z'`
-  /// - `'2012-02-27 13:27:00,123456z'`
-  /// - `'20120227 13:27:00'`
-  /// - `'20120227T132700'`
-  /// - `'20120227'`
-  /// - `'+20120227'`
-  /// - `'2012-02-27T14Z'`
-  /// - `'2012-02-27T14+00:00'`
-  /// - `'-123450101 00:00:00 Z'`: in the year -12345.
-  /// - `'2002-02-27T14:00:00-0500'`: Same as `'2002-02-27T19:00:00Z'`
+  /// {@macro Pick.asDateTime}
   DateTime? asDateTimeOrNull() {
     if (value == null) return null;
     try {

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -15,8 +15,8 @@ extension DoublePick on RequiredPick {
         return parsed;
       }
     }
-    throw PickException(
-        "value $value of type ${value.runtimeType} at location ${location()} can't be casted to double");
+    throw PickException('value $value of type ${value.runtimeType} '
+        'at location ${location()} can not be casted to double');
   }
 }
 

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -16,23 +16,17 @@ extension DoublePick on RequiredPick {
       }
     }
     throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be casted to double');
+        'at location ${location()} can not be parsed as double');
   }
 }
 
 extension NullableDoublePick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'By default values are optional and can only be converted when a fallback is provided '
-      'i.e. .asDoubleOrNull() which falls back to `null`. '
-      'Use .required().asDouble() in cases the value is mandatory. '
-      "It will crash when the value couldn't be picked.")
-  double asDouble() {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not an instance of double');
-    }
+  @Deprecated('Use .asDoubleOrThrow()')
+  double Function() get asDouble => asDoubleOrThrow;
+
+  double asDoubleOrThrow() {
+    withContext(requiredPickErrorHintKey,
+        'Use asDoubleOrNull() when the value may be null/absent at some point (double?).');
     return required().asDouble();
   }
 

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -23,23 +23,17 @@ extension IntPick on RequiredPick {
       }
     }
     throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be casted to int');
+        'at location ${location()} can not be parsed as int');
   }
 }
 
 extension NullableIntPick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'By default values are optional and can only be converted when a fallback is provided '
-      'i.e. .asIntOrNUll() which falls back to `null`. '
-      'Use .required().asInt() in cases the value is mandatory. '
-      "It will crash when the value couldn't be picked.")
-  int asInt() {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not an instance of int');
-    }
+  @Deprecated('Use .asIntOrThrow()')
+  int Function() get asInt => asIntOrThrow;
+
+  int asIntOrThrow() {
+    withContext(requiredPickErrorHintKey,
+        'Use asIntOrNull() when the value may be null/absent at some point (int?).');
     return required().asInt();
   }
 

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -31,6 +31,9 @@ extension NullableIntPick on Pick {
   @Deprecated('Use .asIntOrThrow()')
   int Function() get asInt => asIntOrThrow;
 
+  /// Returns the picked [value] as [int] or throws
+  ///
+  /// {@macro Pick.asInt}
   int asIntOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asIntOrNull() when the value may be null/absent at some point (int?).');

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -22,8 +22,8 @@ extension IntPick on RequiredPick {
         return parsed;
       }
     }
-    throw PickException(
-        "value $value of type ${value.runtimeType} at location ${location()} can't be casted to int");
+    throw PickException('value $value of type ${value.runtimeType} '
+        'at location ${location()} can not be casted to int');
   }
 }
 

--- a/lib/src/pick_let.dart
+++ b/lib/src/pick_let.dart
@@ -21,6 +21,25 @@ extension Let on RequiredPick {
 }
 
 extension NullableLet on Pick {
+  /// Maps the non-null [value] and returns the result. Throws when [value] == null
+  ///
+  /// Shorthand for `.required().let(mapFn)`
+  ///
+  /// This methods allows mapping values in a single line
+  ///
+  /// Example:
+  ///
+  /// ```
+  /// // with letOrThrow
+  /// User user =
+  ///   pick(json, 'users', 0).letOrThrow((pick) => User.fromJson(pick.asMap()));
+  /// ```
+  R letOrThrow<R>(R Function(RequiredPick pick) block) {
+    withContext(requiredPickErrorHintKey,
+        'Use letOrNull() when the value may be null at some point.');
+    return block(required());
+  }
+
   /// Maps the pick if [value] != null and returns the result.
   ///
   /// This methods allows mapping of optional values in a single line

--- a/lib/src/pick_let.dart
+++ b/lib/src/pick_let.dart
@@ -36,7 +36,7 @@ extension NullableLet on Pick {
   /// ```
   R letOrThrow<R>(R Function(RequiredPick pick) block) {
     withContext(requiredPickErrorHintKey,
-        'Use letOrNull() when the value may be null at some point.');
+        'Use letOrNull() when the value may be null/absent at some point.');
     return block(required());
   }
 

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -18,18 +18,14 @@ extension ListPick on RequiredPick {
 }
 
 extension NullableListPick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'By default values are optional and can only be converted when a fallback is provided '
-      'i.e. .asListOrNull() which falls back to `null`. '
-      'Use .required().asList() in cases the value is mandatory. '
-      "It will crash when the value couldn't be picked.")
+  @Deprecated('Use .asListOrThrow()')
   List<T> asList<T>([T Function(Pick)? map]) {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not an instance of List<$T>');
-    }
+    return asListOrThrow(map);
+  }
+
+  List<T> asListOrThrow<T>([T Function(Pick)? map]) {
+    withContext(requiredPickErrorHintKey,
+        'Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<$T>?).');
     return required().asList(map);
   }
 

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -12,8 +12,8 @@ extension ListPick on RequiredPick {
           .map((it) => map(Pick(it, path: [...path, i++], context: context)))
           .toList(growable: false);
     }
-    throw PickException(
-        "value $value of type ${value.runtimeType} at location ${location()} can't be casted to List<dynamic>");
+    throw PickException('value $value of type ${value.runtimeType} '
+        'at location ${location()} can not be casted to List<dynamic>');
   }
 }
 

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -15,18 +15,12 @@ extension MapPick on RequiredPick {
 }
 
 extension NullableMapPick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'By default values are optional and can only be converted when a fallback is provided '
-      'i.e. .asMapOrNull() which falls back to `null`. '
-      'Use .required().asMap() in cases the value is mandatory. '
-      "It will crash when the value couldn't be picked.")
-  Map<RK, RV> asMap<RK, RV>() {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not an instance of Map<dynamic, dynamic>');
-    }
+  @Deprecated('Use .asMapOrThrow()')
+  Map<RK, RV> Function<RK, RV>() get asMap => asMapOrThrow;
+
+  Map<RK, RV> asMapOrThrow<RK, RV>() {
+    withContext(requiredPickErrorHintKey,
+        'Use asMapOrEmpty()/asMapOrNull() when the value may be null/absent at some point (Map<$RK, $RV>?).');
     return required().asMap();
   }
 

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -9,8 +9,8 @@ extension MapPick on RequiredPick {
       // and not lazily type checked when accessing them
       return Map.of(view);
     }
-    throw PickException(
-        "value $value of type ${value.runtimeType} at location ${location()} can't be casted to Map<dynamic, dynamic>");
+    throw PickException('value $value of type ${value.runtimeType} '
+        'at location ${location()} can not be casted to Map<dynamic, dynamic>');
   }
 }
 

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -1,7 +1,8 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension StringPick on RequiredPick {
-  /// Returns the picked [value] as String
+  /// Returns the picked [value] as String representation; only throws when
+  /// the value is `null`.
   ///
   /// {@template Pick.asString}
   /// Parses the picked value as String. If the value is not already a [String]
@@ -25,17 +26,16 @@ extension StringPick on RequiredPick {
 }
 
 extension NullableStringPick on Pick {
-  // This deprecation is used to promote the `.required()` in auto-completion.
-  // Therefore it is not intended to be ever removed
-  @Deprecated(
-      'Use .required().asString() or .asRequiredString() when you require the value to be non-null. '
-      'Use .asStringOrNull() when you expect the value to be nullable')
-  String asString() {
-    if (value == null) {
-      throw PickException(
-          'value at location ${location()} is null and not a String. '
-          'Use asStringOrNull() when null is a valid value (String?)');
-    }
+  @Deprecated('Use .asStringOrThrow()')
+  String Function() get asString => asStringOrThrow;
+
+  /// Returns the picked [value] as String representation; only throws when
+  /// the value is `null`.
+  ///
+  /// {@macro Pick.asString}
+  String asStringOrThrow() {
+    withContext(requiredPickErrorHintKey,
+        'Use asStringOrNull() when the value may be null/absent at some point (String?).');
     return required().asString();
   }
 

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,10 +1,12 @@
 import 'src/pick_bool_test.dart' as pick_bool_test;
+import 'src/pick_datetime_test.dart' as pick_datetime_test;
 import 'src/pick_let_test.dart' as pick_let_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
 
 void main() {
   pick_bool_test.main();
+  pick_datetime_test.main();
   pick_let_test.main();
   pick_test.main();
   required_pick_test.main();

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,8 +1,10 @@
+import 'src/pick_bool_test.dart' as pick_bool_test;
 import 'src/pick_let_test.dart' as pick_let_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
 
 void main() {
+  pick_bool_test.main();
   pick_let_test.main();
   pick_test.main();
   required_pick_test.main();

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,6 +1,7 @@
 import 'src/pick_bool_test.dart' as pick_bool_test;
 import 'src/pick_datetime_test.dart' as pick_datetime_test;
 import 'src/pick_double_test.dart' as pick_double_test;
+import 'src/pick_int_test.dart' as pick_int_test;
 import 'src/pick_let_test.dart' as pick_let_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
@@ -9,6 +10,7 @@ void main() {
   pick_bool_test.main();
   pick_datetime_test.main();
   pick_double_test.main();
+  pick_int_test.main();
   pick_let_test.main();
   pick_test.main();
   required_pick_test.main();

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -3,6 +3,7 @@ import 'src/pick_datetime_test.dart' as pick_datetime_test;
 import 'src/pick_double_test.dart' as pick_double_test;
 import 'src/pick_int_test.dart' as pick_int_test;
 import 'src/pick_let_test.dart' as pick_let_test;
+import 'src/pick_string_test.dart' as pick_string_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
 
@@ -12,6 +13,7 @@ void main() {
   pick_double_test.main();
   pick_int_test.main();
   pick_let_test.main();
+  pick_string_test.main();
   pick_test.main();
   required_pick_test.main();
 }

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -3,6 +3,7 @@ import 'src/pick_datetime_test.dart' as pick_datetime_test;
 import 'src/pick_double_test.dart' as pick_double_test;
 import 'src/pick_int_test.dart' as pick_int_test;
 import 'src/pick_let_test.dart' as pick_let_test;
+import 'src/pick_list_test.dart' as pick_list_test;
 import 'src/pick_map_test.dart' as pick_map_test;
 import 'src/pick_string_test.dart' as pick_string_test;
 import 'src/pick_test.dart' as pick_test;
@@ -14,6 +15,7 @@ void main() {
   pick_double_test.main();
   pick_int_test.main();
   pick_let_test.main();
+  pick_list_test.main();
   pick_map_test.main();
   pick_string_test.main();
   pick_test.main();

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,5 +1,6 @@
 import 'src/pick_bool_test.dart' as pick_bool_test;
 import 'src/pick_datetime_test.dart' as pick_datetime_test;
+import 'src/pick_double_test.dart' as pick_double_test;
 import 'src/pick_let_test.dart' as pick_let_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
@@ -7,6 +8,7 @@ import 'src/required_pick_test.dart' as required_pick_test;
 void main() {
   pick_bool_test.main();
   pick_datetime_test.main();
+  pick_double_test.main();
   pick_let_test.main();
   pick_test.main();
   required_pick_test.main();

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,7 +1,9 @@
+import 'src/pick_let_test.dart' as pick_let_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
 
 void main() {
+  pick_let_test.main();
   pick_test.main();
   required_pick_test.main();
 }

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -3,6 +3,7 @@ import 'src/pick_datetime_test.dart' as pick_datetime_test;
 import 'src/pick_double_test.dart' as pick_double_test;
 import 'src/pick_int_test.dart' as pick_int_test;
 import 'src/pick_let_test.dart' as pick_let_test;
+import 'src/pick_map_test.dart' as pick_map_test;
 import 'src/pick_string_test.dart' as pick_string_test;
 import 'src/pick_test.dart' as pick_test;
 import 'src/required_pick_test.dart' as required_pick_test;
@@ -13,6 +14,7 @@ void main() {
   pick_double_test.main();
   pick_int_test.main();
   pick_let_test.main();
+  pick_map_test.main();
   pick_string_test.main();
   pick_test.main();
   required_pick_test.main();

--- a/test/src/pick_bool_test.dart
+++ b/test/src/pick_bool_test.dart
@@ -1,0 +1,65 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asBool*', () {
+    test('asBoolOrNull()', () {
+      expect(pick(true).asBoolOrNull(), isTrue);
+      expect(pick('a').asBoolOrNull(), isNull);
+      expect(nullPick().asBoolOrNull(), isNull);
+    });
+
+    test('asBoolOrTrue()', () {
+      expect(pick(true).asBoolOrTrue(), isTrue);
+      expect(pick(false).asBoolOrTrue(), isFalse);
+      expect(pick('a').asBoolOrTrue(), isTrue);
+      expect(nullPick().asBoolOrTrue(), isTrue);
+    });
+
+    test('asBoolOrFalse()', () {
+      expect(pick(true).asBoolOrFalse(), isTrue);
+      expect(pick(false).asBoolOrFalse(), isFalse);
+      expect(pick('a').asBoolOrFalse(), isFalse);
+      expect(nullPick().asBoolOrFalse(), isFalse);
+    });
+
+    test('deprecated asBool forwards to asBoolOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick(true).asBool(), isTrue);
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('true').asBool(), isTrue);
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('false').asBool(), isFalse);
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => pick('Bubblegum').asBool(),
+        throwsA(pickException(
+            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+      );
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => nullPick().asBool(),
+        throwsA(pickException(
+            containing: ['unknownKey', 'asBoolOrNull', 'null', 'bool?'])),
+      );
+    });
+
+    test('asBoolOrThrow()', () {
+      expect(pick(true).asBoolOrThrow(), isTrue);
+      expect(pick('true').asBoolOrThrow(), isTrue);
+      expect(pick('false').asBoolOrThrow(), isFalse);
+      expect(
+        () => pick('Bubblegum').asBoolOrThrow(),
+        throwsA(pickException(
+            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+      );
+      expect(
+        () => nullPick().asBoolOrThrow(),
+        throwsA(pickException(
+            containing: ['unknownKey', 'asBoolOrNull', 'null', 'bool?'])),
+      );
+    });
+  });
+}

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -26,6 +26,12 @@ void main() {
             'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
           ])),
         );
+
+        expect(
+          () => nullPick().asDateTimeOrThrow(),
+          throwsA(
+              pickException(containing: ['unknownKey', 'null', 'DateTime'])),
+        );
       });
 
       test('wrong type throws', () {
@@ -34,6 +40,11 @@ void main() {
           throwsA(pickException(containing: [
             "value Instance of 'Object' of type Object at location `<root>` can not be parsed as DateTime"
           ])),
+        );
+        expect(
+          () => pick('Bubblegum').asDateTimeOrThrow(),
+          throwsA(
+              pickException(containing: ['Bubblegum', 'String', 'DateTime'])),
         );
       });
     });

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -1,0 +1,95 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asDateTime*', () {
+    group('asDateTimeOrThrow', () {
+      test('parse String', () {
+        expect(pick('2012-02-27 13:27:00').asDateTimeOrThrow(),
+            DateTime(2012, 2, 27, 13, 27));
+        expect(pick('2012-02-27 13:27:00.123456z').asDateTimeOrThrow(),
+            DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
+      });
+
+      test('parse DateTime', () {
+        final time = DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456);
+        expect(pick(time.toString()).asDateTimeOrThrow(), time);
+        expect(pick(time).asDateTimeOrThrow(), time);
+      });
+
+      test('null throws', () {
+        expect(
+          () => nullPick().asDateTimeOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null at some point (DateTime?).'
+          ])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+          () => pick(Object()).asDateTimeOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location `<root>` can not be parsed as DateTime"
+          ])),
+        );
+      });
+    });
+
+    group('asDateTime forwards to asDateTimeOrThrow', () {
+      test('parse String', () {
+        // ignore: deprecated_member_use_from_same_package
+        expect(pick('2012-02-27 13:27:00').asDateTime(),
+            DateTime(2012, 2, 27, 13, 27));
+        // ignore: deprecated_member_use_from_same_package
+        expect(pick('2012-02-27 13:27:00.123456z').asDateTime(),
+            DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
+      });
+
+      test('parse DateTime', () {
+        final time = DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456);
+        // ignore: deprecated_member_use_from_same_package
+        expect(pick(time.toString()).asDateTime(), time);
+        // ignore: deprecated_member_use_from_same_package
+        expect(pick(time).asDateTime(), time);
+      });
+
+      test('null throws', () {
+        expect(
+          // ignore: deprecated_member_use_from_same_package
+          () => nullPick().asDateTime(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null at some point (DateTime?).'
+          ])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+          // ignore: deprecated_member_use_from_same_package
+          () => pick(Object()).asDateTime(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location `<root>` can not be parsed as DateTime"
+          ])),
+        );
+      });
+    });
+
+    group('asDateTimeOrNull', () {
+      test('parse String', () {
+        expect(pick('2012-02-27 13:27:00').asDateTimeOrNull(),
+            DateTime(2012, 2, 27, 13, 27));
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asDateTimeOrNull(), isNull);
+      });
+
+      test('wrong type returns null', () {
+        expect(pick(Object()).asDateTimeOrNull(), isNull);
+      });
+    });
+  });
+}

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -23,7 +23,7 @@ void main() {
         expect(
           () => nullPick().asDateTimeOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null at some point (DateTime?).'
+            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
           ])),
         );
       });
@@ -61,7 +61,7 @@ void main() {
           // ignore: deprecated_member_use_from_same_package
           () => nullPick().asDateTime(),
           throwsA(pickException(containing: [
-            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null at some point (DateTime?).'
+            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
           ])),
         );
       });

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -49,43 +49,17 @@ void main() {
       });
     });
 
-    group('asDateTime forwards to asDateTimeOrThrow', () {
-      test('parse String', () {
+    test('deprecated asDateTime forwards to asDateTimeOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('2012-02-27 13:27:00').asDateTime(),
+          DateTime(2012, 2, 27, 13, 27));
+      expect(
         // ignore: deprecated_member_use_from_same_package
-        expect(pick('2012-02-27 13:27:00').asDateTime(),
-            DateTime(2012, 2, 27, 13, 27));
-        // ignore: deprecated_member_use_from_same_package
-        expect(pick('2012-02-27 13:27:00.123456z').asDateTime(),
-            DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
-      });
-
-      test('parse DateTime', () {
-        final time = DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456);
-        // ignore: deprecated_member_use_from_same_package
-        expect(pick(time.toString()).asDateTime(), time);
-        // ignore: deprecated_member_use_from_same_package
-        expect(pick(time).asDateTime(), time);
-      });
-
-      test('null throws', () {
-        expect(
-          // ignore: deprecated_member_use_from_same_package
-          () => nullPick().asDateTime(),
-          throwsA(pickException(containing: [
-            'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
-          ])),
-        );
-      });
-
-      test('wrong type throws', () {
-        expect(
-          // ignore: deprecated_member_use_from_same_package
-          () => pick(Object()).asDateTime(),
-          throwsA(pickException(containing: [
-            "value Instance of 'Object' of type Object at location `<root>` can not be parsed as DateTime"
-          ])),
-        );
-      });
+        () => nullPick().asDateTime(),
+        throwsA(pickException(containing: [
+          'required value at location `unknownKey` is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
+        ])),
+      );
     });
 
     group('asDateTimeOrNull', () {

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -1,0 +1,80 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asDouble*', () {
+    group('asDoubleOrThrow', () {
+      test('parse double', () {
+        expect(pick(1.0).asDoubleOrThrow(), 1.0);
+        expect(pick(double.infinity).asDoubleOrThrow(), double.infinity);
+      });
+
+      test('parse int', () {
+        expect(pick(1).asDoubleOrThrow(), 1.0);
+      });
+      test('parse int String', () {
+        expect(pick('1').asDoubleOrThrow(), 1.0);
+      });
+
+      test('parse double String', () {
+        expect(pick('1.0').asDoubleOrThrow(), 1.0);
+        expect(pick('25.4634').asDoubleOrThrow(), 25.4634);
+        expect(pick('12345.01').asDoubleOrThrow(), 12345.01);
+      });
+
+      test('null throws', () {
+        expect(
+          () => nullPick().asDoubleOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asDoubleOrNull() when the value may be null/absent at some point (double?).'
+          ])),
+        );
+
+        expect(
+          () => nullPick().asDoubleOrThrow(),
+          throwsA(pickException(containing: ['unknownKey', 'null', 'double'])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+          () => pick(Object()).asDoubleOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location `<root>` can not be parsed as double"
+          ])),
+        );
+
+        expect(
+          () => pick('Bubblegum').asDoubleOrThrow(),
+          throwsA(pickException(containing: ['Bubblegum', 'String', 'double'])),
+        );
+      });
+    });
+
+    test('deprecated asDouble forwards to asDoubleOrThrow', () {
+      expect(pick('1').asDouble(), 1.0);
+      expect(
+        () => pick(Object()).asDouble(),
+        throwsA(pickException(containing: [
+          "value Instance of 'Object' of type Object at location `<root>` can not be parsed as double"
+        ])),
+      );
+    });
+
+    group('asDoubleOrNull', () {
+      test('parse String', () {
+        expect(pick('2012').asDoubleOrNull(), 2012);
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asDoubleOrNull(), isNull);
+      });
+
+      test('wrong type returns null', () {
+        expect(pick(Object()).asDoubleOrNull(), isNull);
+      });
+    });
+  });
+}

--- a/test/src/pick_int_test.dart
+++ b/test/src/pick_int_test.dart
@@ -1,0 +1,73 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asInt*', () {
+    group('asIntOrThrow', () {
+      test('parse Int', () {
+        expect(pick(1).asIntOrThrow(), 1);
+        expect(pick(35).asIntOrThrow(), 35);
+      });
+
+      test('parse double', () {
+        expect(pick(1.0).asIntOrThrow(), 1);
+      });
+
+      test('parse int String', () {
+        expect(pick('1').asIntOrThrow(), 1);
+        expect(pick('123').asIntOrThrow(), 123);
+      });
+
+      test('null throws', () {
+        expect(
+          () => nullPick().asIntOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asIntOrNull() when the value may be null/absent at some point (int?).'
+          ])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+          () => pick(Object()).asIntOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location `<root>` can not be parsed as int"
+          ])),
+        );
+
+        expect(
+          () => pick('Bubblegum').asIntOrThrow(),
+          throwsA(pickException(containing: ['Bubblegum', 'String', 'int'])),
+        );
+      });
+    });
+
+    test('deprecated asInt forwards to asIntOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('1').asInt(), 1.0);
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => pick(Object()).asInt(),
+        throwsA(pickException(containing: [
+          "value Instance of 'Object' of type Object at location `<root>` can not be parsed as int"
+        ])),
+      );
+    });
+
+    group('asIntOrNull', () {
+      test('parse String', () {
+        expect(pick('2012').asIntOrNull(), 2012);
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asIntOrNull(), isNull);
+      });
+
+      test('wrong type returns null', () {
+        expect(pick(Object()).asIntOrNull(), isNull);
+      });
+    });
+  });
+}

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -1,0 +1,67 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().let*', () {
+    test('let()', () {
+      expect(
+          pick({'name': 'John Snow'})
+              .required()
+              .let((pick) => Person.fromJson(pick.asMap())),
+          Person(name: 'John Snow'));
+      expect(
+          pick({'name': 'John Snow'})
+              .required()
+              .let((pick) => Person.fromJson(pick.asMap())),
+          Person(name: 'John Snow'));
+      expect(
+          () => nullPick()
+              .required()
+              .let((pick) => Person.fromJson(pick.asMap())),
+          throwsA(pickException(containing: ['unknownKey', 'absent'])));
+    });
+
+    test('letOrNull()', () {
+      expect(
+          pick({'name': 'John Snow'})
+              .letOrNull((pick) => Person.fromJson(pick.asMap())),
+          Person(name: 'John Snow'));
+      expect(nullPick().letOrNull((pick) => Person.fromJson(pick.asMap())),
+          isNull);
+      expect(
+          () => pick('a').letOrNull((pick) => Person.fromJson(pick.asMap())),
+          throwsA(isA<PickException>().having(
+            (e) => e.message,
+            'message',
+            contains(
+                "value a of type String at location `<root>` can't be casted to Map<dynamic, dynamic>"),
+          )));
+      expect(
+          () => pick({'asdf': 'John Snow'})
+              .letOrNull((pick) => Person.fromJson(pick.asMap())),
+          throwsA(isA<PickException>().having((e) => e.message, 'message',
+              contains('required value at location `name` is absent'))));
+    });
+
+    test('letOrThrow()', () {
+      expect(
+          pick({'name': 'John Snow'})
+              .letOrThrow((pick) => Person.fromJson(pick.asMap())),
+          Person(name: 'John Snow'));
+      expect(
+        () => nullPick().letOrThrow((pick) => Person.fromJson(pick.asMap())),
+        throwsA(pickException(containing: [
+          'required value at location `unknownKey` is absent. Use letOrNull() when the value may be null at some point.'
+        ])),
+      );
+      expect(
+        () => pick({'asdf': 'John Snow'})
+            .letOrThrow((pick) => Person.fromJson(pick.asMap())),
+        throwsA(pickException(
+            containing: ['required value at location `name` is absent'])),
+      );
+    });
+  });
+}

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -53,7 +53,7 @@ void main() {
       expect(
         () => nullPick().letOrThrow((pick) => Person.fromJson(pick.asMap())),
         throwsA(pickException(containing: [
-          'required value at location `unknownKey` is absent. Use letOrNull() when the value may be null at some point.'
+          'required value at location `unknownKey` is absent. Use letOrNull() when the value may be null/absent at some point.'
         ])),
       );
       expect(

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -36,7 +36,7 @@ void main() {
             (e) => e.message,
             'message',
             contains(
-                "value a of type String at location `<root>` can't be casted to Map<dynamic, dynamic>"),
+                'value a of type String at location `<root>` can not be casted to Map<dynamic, dynamic>'),
           )));
       expect(
           () => pick({'asdf': 'John Snow'})

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -1,0 +1,237 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asList*', () {
+    group('asListOrThrow', () {
+      test('pipe through List', () {
+        expect(pick([1, 2, 3]).asListOrThrow(), [1, 2, 3]);
+      });
+
+      test('null throws', () {
+        expect(
+          () => nullPick().asListOrThrow<String>(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<String>?).'
+          ])),
+        );
+      });
+
+      test('map empty list to empty list', () {
+        expect(
+          pick([])
+              .asListOrThrow((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [],
+        );
+      });
+
+      test('map to List<Person>', () {
+        expect(
+          pick([
+            {'name': 'John Snow'},
+            {'name': 'Daenerys Targaryen'},
+          ]).asListOrThrow((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [
+            Person(name: 'John Snow'),
+            Person(name: 'Daenerys Targaryen'),
+          ],
+        );
+      });
+
+      test('map to List<Person?>', () {
+        expect(
+          pick([
+            {'name': 'John Snow'},
+            {'name': 'Daenerys Targaryen'},
+            null, // <-- valid value
+          ]).asListOrThrow((pick) =>
+              pick.letOrNull((pick) => Person.fromJson(pick.asMap()))),
+          [
+            Person(name: 'John Snow'),
+            Person(name: 'Daenerys Targaryen'),
+            null,
+          ],
+        );
+      });
+
+      test('map reports item parsing errors', () {
+        expect(
+          () => pick([
+            {'name': 'John Snow'},
+            {'asdf': 'Daenerys Targaryen'}, // <-- missing name key
+          ]).asListOrThrow((pick) => Person.fromJson(pick.asMapOrThrow())),
+          throwsA(pickException(
+              containing: ['required value at location `name` is absent'])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+          () => pick('Bubblegum').asListOrThrow(),
+          throwsA(pickException(
+              containing: ['Bubblegum', 'String', 'List<dynamic>'])),
+        );
+        expect(
+          () => pick(Object()).asListOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location `<root>` can not be casted to List<dynamic>"
+          ])),
+        );
+      });
+    });
+
+    test('deprecated asList forwards to asListOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick([1, 2, 3]).asList(), [1, 2, 3]);
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => pick(Object()).asList(),
+        throwsA(pickException(containing: [
+          "value Instance of 'Object' of type Object at location `<root>` can not be casted to List<dynamic>"
+        ])),
+      );
+    });
+
+    group('asListOrEmpty', () {
+      test('pick value', () {
+        expect(pick([1, 2, 3]).asListOrEmpty(), [1, 2, 3]);
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asListOrEmpty<int>(), []);
+      });
+
+      test('wrong type returns empty', () {
+        expect(pick(Object()).asListOrEmpty<int>(), []);
+      });
+
+      test('map empty list to empty list', () {
+        expect(
+          pick([])
+              .asListOrEmpty((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [],
+        );
+      });
+
+      test('map null list to empty list', () {
+        expect(
+          nullPick()
+              .asListOrEmpty((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [],
+        );
+      });
+
+      test('map to List<Person>', () {
+        expect(
+          pick([
+            {'name': 'John Snow'},
+            {'name': 'Daenerys Targaryen'},
+          ]).asListOrEmpty((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [
+            Person(name: 'John Snow'),
+            Person(name: 'Daenerys Targaryen'),
+          ],
+        );
+      });
+
+      test('map to List<Person?>', () {
+        expect(
+          pick([
+            {'name': 'John Snow'},
+            {'name': 'Daenerys Targaryen'},
+            null, // <-- valid value
+          ]).asListOrEmpty((pick) =>
+              pick.letOrNull((pick) => Person.fromJson(pick.asMap()))),
+          [
+            Person(name: 'John Snow'),
+            Person(name: 'Daenerys Targaryen'),
+            null,
+          ],
+        );
+      });
+
+      test('map reports item parsing errors', () {
+        expect(
+          () => pick([
+            {'name': 'John Snow'},
+            {'asdf': 'Daenerys Targaryen'}, // <-- missing name key
+          ]).asListOrEmpty((pick) => Person.fromJson(pick.asMapOrThrow())),
+          throwsA(pickException(
+              containing: ['required value at location `name` is absent'])),
+        );
+      });
+    });
+
+    group('asListOrNull', () {
+      test('pick value', () {
+        expect(pick([1, 2, 3]).asListOrNull(), [1, 2, 3]);
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asListOrNull(), isNull);
+      });
+
+      test('wrong type returns empty', () {
+        expect(pick(Object()).asListOrNull(), isNull);
+      });
+
+      test('map empty list to empty list', () {
+        expect(
+          pick([]).asListOrNull((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [],
+        );
+      });
+
+      test('map null list to null', () {
+        expect(
+          nullPick()
+              .asListOrNull((pick) => Person.fromJson(pick.asMapOrThrow())),
+          null,
+        );
+      });
+
+      test('map to List<Person>', () {
+        expect(
+          pick([
+            {'name': 'John Snow'},
+            {'name': 'Daenerys Targaryen'},
+          ]).asListOrNull((pick) => Person.fromJson(pick.asMapOrThrow())),
+          [
+            Person(name: 'John Snow'),
+            Person(name: 'Daenerys Targaryen'),
+          ],
+        );
+      });
+
+      test('map to List<Person?>', () {
+        expect(
+          pick([
+            {'name': 'John Snow'},
+            {'name': 'Daenerys Targaryen'},
+            null, // <-- valid value
+          ]).asListOrNull((pick) =>
+              pick.letOrNull((pick) => Person.fromJson(pick.asMap()))),
+          [
+            Person(name: 'John Snow'),
+            Person(name: 'Daenerys Targaryen'),
+            null,
+          ],
+        );
+      });
+
+      test('map reports item parsing errors', () {
+        final data = [
+          {'name': 'John Snow'},
+          {'asdf': 'Daenerys Targaryen'}, // <-- missing name key
+        ];
+        expect(
+            () => pick(data)
+                .asListOrNull((pick) => Person.fromJson(pick.asMapOrThrow())),
+            throwsA(isA<PickException>().having((e) => e.message, 'message',
+                contains('required value at location `name` is absent'))));
+      });
+    });
+  });
+}

--- a/test/src/pick_map_test.dart
+++ b/test/src/pick_map_test.dart
@@ -1,0 +1,151 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asMap*', () {
+    group('asMapOrThrow', () {
+      test('pipe through Map', () {
+        expect(pick({'ab': 'cd'}).asMapOrThrow(), {'ab': 'cd'});
+      });
+
+      test('null throws', () {
+        expect(
+          () => nullPick().asMapOrThrow<String, bool>(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asMapOrEmpty()/asMapOrNull() when the value may be null/absent at some point (Map<String, bool>?).'
+          ])),
+        );
+      });
+
+      test('throws for cast error', () {
+        final dynamic data = {
+          'a': {'some': 'value'}
+        };
+
+        try {
+          final parsed = pick(data).asMapOrThrow<String, bool>();
+          fail('casted map without verifying the types. '
+              'Expected Map<String, bool> but was ${parsed.runtimeType}');
+          // ignore: avoid_catching_errors
+        } on TypeError catch (e) {
+          expect(
+            e,
+            const TypeMatcher<TypeError>().having(
+              (e) => e.toString(),
+              'message',
+              stringContainsInOrder(
+                  ['<String, String>', 'is not a subtype of type', 'bool']),
+            ),
+          );
+          // ignore: avoid_catching_errors, deprecated_member_use
+        } on CastError catch (e) {
+          // backwards compatibility for Dart 2.7
+          // CastError was replaced with TypeError in Dart 2.8
+          expect(
+            e,
+            // ignore: deprecated_member_use
+            const TypeMatcher<CastError>().having(
+              (e) => e.toString(),
+              'message',
+              stringContainsInOrder(
+                  ['<String, String>', 'is not a subtype of type', 'bool']),
+            ),
+          );
+        }
+      });
+
+      test('wrong type throws', () {
+        expect(
+          () => pick('Bubblegum').asMapOrThrow(),
+          throwsA(pickException(
+              containing: ['Bubblegum', 'String', 'Map<dynamic, dynamic>'])),
+        );
+        expect(
+          () => pick(Object()).asMapOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location `<root>` can not be casted to Map<dynamic, dynamic>"
+          ])),
+        );
+      });
+    });
+
+    test('deprecated asMap forwards to asMapOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick({'ab': 'cd'}).asMap(), {'ab': 'cd'});
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => pick(Object()).asMap(),
+        throwsA(pickException(containing: [
+          "value Instance of 'Object' of type Object at location `<root>` can not be casted to Map<dynamic, dynamic>"
+        ])),
+      );
+    });
+
+    group('asMapOrEmpty', () {
+      test('pick value', () {
+        expect(pick({'ab': 'cd'}).asMapOrEmpty(), {'ab': 'cd'});
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asMapOrEmpty(), {});
+      });
+
+      test('wrong type returns empty', () {
+        expect(pick(Object()).asMapOrEmpty(), {});
+      });
+
+      test('reports errors correctly', () {
+        final dynamic data = {
+          'a': {'some': 'value'}
+        };
+
+        try {
+          final parsed = pick(data).asMapOrEmpty<String, bool>();
+          fail('casted map without verifying the types. '
+              'Expected Map<String, bool> but was ${parsed.runtimeType}');
+          // ignore: avoid_catching_errors
+        } on TypeError catch (e) {
+          expect(
+            e,
+            const TypeMatcher<TypeError>().having(
+              (e) => e.toString(),
+              'message',
+              stringContainsInOrder(
+                  ['<String, String>', 'is not a subtype of type', 'bool']),
+            ),
+          );
+          // ignore: avoid_catching_errors, deprecated_member_use
+        } on CastError catch (e) {
+          // backwards compatibility for Dart 2.7
+          // CastError was replaced with TypeError in Dart 2.8
+          expect(
+            e,
+            // ignore: deprecated_member_use
+            const TypeMatcher<CastError>().having(
+              (e) => e.toString(),
+              'message',
+              stringContainsInOrder(
+                  ['<String, String>', 'is not a subtype of type', 'bool']),
+            ),
+          );
+        }
+      });
+    });
+
+    group('asMapOrNull', () {
+      test('pick value', () {
+        expect(pick({'ab': 'cd'}).asMapOrNull(), {'ab': 'cd'});
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asMapOrNull(), isNull);
+      });
+
+      test('wrong type returns empty', () {
+        expect(pick(Object()).asMapOrNull(), isNull);
+      });
+    });
+  });
+}

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -14,6 +14,22 @@ void main() {
             pick(DateTime(2000)).asStringOrThrow(), '2000-01-01 00:00:00.000');
       });
 
+      test("asString() doesn't transform Maps and Lists with toString", () {
+        expect(
+          () => pick(['a', 'b']).asStringOrThrow(),
+          throwsA(pickException(
+              containing: ['List<String>', 'not a List or Map', '[a, b]'])),
+        );
+        expect(
+          () => pick({'a': 'b'}).asStringOrThrow(),
+          throwsA(pickException(containing: [
+            'Map<String, String>',
+            'not a List or Map',
+            '{a: b}'
+          ])),
+        );
+      });
+
       test('null throws', () {
         expect(
           () => nullPick().asStringOrThrow(),

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -1,0 +1,53 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+import 'pick_test.dart';
+
+void main() {
+  group('pick().asString*', () {
+    group('asStringOrThrow', () {
+      test('parse anything to String', () {
+        expect(pick('adam').asStringOrThrow(), 'adam');
+        expect(pick(1).asStringOrThrow(), '1');
+        expect(pick(2.0).asStringOrThrow(), '2.0');
+        expect(
+            pick(DateTime(2000)).asStringOrThrow(), '2000-01-01 00:00:00.000');
+      });
+
+      test('null throws', () {
+        expect(
+          () => nullPick().asStringOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location `unknownKey` is absent. Use asStringOrNull() when the value may be null/absent at some point (String?).'
+          ])),
+        );
+      });
+    });
+
+    test('deprecated asString forwards to asStringOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('1').asString(), '1');
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => nullPick().asString(),
+        throwsA(pickException(containing: [
+          'required value at location `unknownKey` is absent. Use asStringOrNull() when the value may be null/absent at some point (String?).'
+        ])),
+      );
+    });
+
+    group('asStringOrNull', () {
+      test('parse String', () {
+        expect(pick('2012').asStringOrNull(), '2012');
+      });
+
+      test('null returns null', () {
+        expect(nullPick().asStringOrNull(), isNull);
+      });
+
+      test('as long it is not null it prints toString', () {
+        expect(pick(Object()).asStringOrNull(), "Instance of 'Object'");
+      });
+    });
+  });
+}

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -64,7 +64,7 @@ void main() {
 
     group('isAbsent()', () {
       test('is not absent because value', () {
-        final p = pick("a");
+        final p = pick('a');
         expect(p.value, isNotNull);
         expect(p.isAbsent(), isFalse);
         expect(p.missingValueAtIndex, null);
@@ -248,28 +248,6 @@ void main() {
       expect(nullPick().asDateTimeOrNull(), isNull);
     });
 
-    test('letOrNull()', () {
-      expect(
-          pick({'name': 'John Snow'})
-              .letOrNull((pick) => Person.fromJson(pick.asMap())),
-          Person(name: 'John Snow'));
-      expect(nullPick().letOrNull((pick) => Person.fromJson(pick.asMap())),
-          isNull);
-      expect(
-          () => pick('a').letOrNull((pick) => Person.fromJson(pick.asMap())),
-          throwsA(isA<PickException>().having(
-            (e) => e.message,
-            'message',
-            contains(
-                "value a of type String at location `<root>` can't be casted to Map<dynamic, dynamic>"),
-          )));
-      expect(
-          () => pick({'asdf': 'John Snow'})
-              .letOrNull((pick) => Person.fromJson(pick.asMap())),
-          throwsA(isA<PickException>().having((e) => e.message, 'message',
-              contains('required value at location `name` is null'))));
-    });
-
     test('asListOrEmpty(Pick -> T)', () {
       final data = [
         {'name': 'John Snow'},
@@ -293,7 +271,7 @@ void main() {
           () =>
               pick(data).asListOrEmpty((pick) => Person.fromJson(pick.asMap())),
           throwsA(isA<PickException>().having((e) => e.message, 'message',
-              contains('required value at location `name` is null'))));
+              contains('required value at location `name` is absent'))));
     });
 
     test('asListOrNull(Pick -> T)', () {
@@ -320,7 +298,7 @@ void main() {
           () =>
               pick(data).asListOrNull((pick) => Person.fromJson(pick.asMap())),
           throwsA(isA<PickException>().having((e) => e.message, 'message',
-              contains('required value at location `name` is null'))));
+              contains('required value at location `name` is absent'))));
     });
   });
 
@@ -341,11 +319,11 @@ void main() {
     });
 
     test('documentation example Map', () {
-      final pa = pick({"a": null}, "a");
+      final pa = pick({'a': null}, 'a');
       expect(pa.value, isNull);
       expect(pa.isAbsent(), false);
 
-      final pb = pick({"a": null}, "b");
+      final pb = pick({'a': null}, 'b');
       expect(pb.value, isNull);
       expect(pb.isAbsent(), true);
     });

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -1,10 +1,9 @@
-// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:deep_pick/deep_pick.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Pick', () {
-    test('pick from null returns null Pick with full location', () {
+    test('null pick carries full location', () {
       final p = pick(null, 'some', 'path');
       expect(p.path, ['some', 'path']);
       expect(p.value, null);
@@ -12,7 +11,9 @@ void main() {
 
     test('toString() prints value and path', () {
       expect(
-          Pick('a', path: ['b', 0]).toString(), 'Pick(value=a, path=[b, 0])');
+        Pick('a', path: ['b', 0]).toString(),
+        'Pick(value=a, path=[b, 0])',
+      );
     });
 
     test(
@@ -22,12 +23,10 @@ void main() {
         'set': {'a', 'b', 'c'},
       };
       expect(
-          () => pick(data, 'set', 0),
-          throwsA(isA<PickException>().having(
-              (e) => e.toString(),
-              'toString',
-              allOf(
-                  contains('[set]'), contains('Set'), contains('index (0)')))));
+        () => pick(data, 'set', 0),
+        throwsA(isA<PickException>().having((e) => e.toString(), 'toString',
+            allOf(contains('[set]'), contains('Set'), contains('index (0)')))),
+      );
     });
 
     test('call()', () {
@@ -40,7 +39,7 @@ void main() {
       expect(first.value, {'name': 'John Snow'});
 
       // pick further
-      expect(first.call('name').required().asString(), 'John Snow');
+      expect(first.call('name').asStringOrThrow(), 'John Snow');
     });
 
     test('pick deeper than data structure returns null pick', () {
@@ -69,24 +68,28 @@ void main() {
         expect(p.isAbsent(), isFalse);
         expect(p.missingValueAtIndex, null);
       });
+
       test('is not absent but null', () {
         final p = pick(null);
         expect(p.value, isNull);
         expect(p.isAbsent(), isFalse);
         expect(p.missingValueAtIndex, null);
       });
+
       test('is not absent but null further down', () {
         final p = pick({'a': null}, 'a');
         expect(p.value, isNull);
         expect(p.isAbsent(), isFalse);
         expect(p.missingValueAtIndex, null);
       });
+
       test('is not absent, not null', () {
         final p = pick({'a', 1}, 'b');
         expect(p.value, isNull);
         expect(p.isAbsent(), isTrue);
         expect(p.missingValueAtIndex, 0);
       });
+
       test('is not absent, not null, further down', () {
         final json = {
           'a': {'b': 1}
@@ -96,189 +99,6 @@ void main() {
         expect(p.isAbsent(), isTrue);
         expect(p.missingValueAtIndex, 1);
       });
-    });
-  });
-
-  group('parsing', () {
-    test('asStringOrNull()', () {
-      expect(pick('adam').asStringOrNull(), 'adam');
-      expect(pick(1).asStringOrNull(), '1');
-      expect(pick(DateTime(2000)).asStringOrNull(), '2000-01-01 00:00:00.000');
-      expect(nullPick().asStringOrNull(), isNull);
-    });
-
-    test('asMapOrNull()', () {
-      expect(pick({'ab': 'cd'}).asMapOrNull(), {'ab': 'cd'});
-      expect(pick(1).asMapOrNull(), isNull);
-      expect(nullPick().asMapOrNull(), isNull);
-    });
-
-    test('asMapOrNull() reports errors correctly', () {
-      final dynamic data = {
-        'a': {'some': 'value'}
-      };
-
-      try {
-        final parsed = pick(data).asMapOrNull<String, bool>();
-        fail('casted map without verifying the types. '
-            'Expected Map<String, bool> but was ${parsed.runtimeType}');
-        // ignore: avoid_catching_errors
-      } on TypeError catch (e) {
-        expect(
-          e,
-          const TypeMatcher<TypeError>().having(
-            (e) => e.toString(),
-            'message',
-            stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool']),
-          ),
-        );
-        // ignore: avoid_catching_errors, deprecated_member_use
-      } on CastError catch (e) {
-        // backwards compatibility for Dart 2.7
-        // CastError was replaced with TypeError in Dart 2.8
-        expect(
-          e,
-          // ignore: deprecated_member_use
-          const TypeMatcher<CastError>().having(
-            (e) => e.toString(),
-            'message',
-            stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool']),
-          ),
-        );
-      }
-    });
-
-    test('asMapOrEmpty()', () {
-      expect(pick({'ab': 'cd'}).asMapOrEmpty(), {'ab': 'cd'});
-      expect(pick('a').asMapOrEmpty(), {});
-      expect(nullPick().asMapOrEmpty(), {});
-    });
-
-    test('asMapOrEmpty() reports errors correctly', () {
-      final dynamic data = {
-        'a': {'some': 'value'}
-      };
-
-      try {
-        final parsed = pick(data).asMapOrEmpty<String, bool>();
-        fail('casted map without verifying the types. '
-            'Expected Map<String, bool> but was ${parsed.runtimeType}');
-        // ignore: avoid_catching_errors
-      } on TypeError catch (e) {
-        expect(
-          e,
-          const TypeMatcher<TypeError>().having(
-            (e) => e.toString(),
-            'message',
-            stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool']),
-          ),
-        );
-        // ignore: avoid_catching_errors, deprecated_member_use
-      } on CastError catch (e) {
-        // backwards compatibility for Dart 2.7
-        // CastError was replaced with TypeError in Dart 2.8
-        expect(
-          e,
-          // ignore: deprecated_member_use
-          const TypeMatcher<CastError>().having(
-            (e) => e.toString(),
-            'message',
-            stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool']),
-          ),
-        );
-      }
-    });
-
-    test('asListOrNull()', () {
-      expect(pick([1, 2, 3]).asListOrNull<int>(), [1, 2, 3]);
-      expect(pick('john').asListOrNull<int>(), isNull);
-      expect(nullPick().asListOrNull<int>(), isNull);
-    });
-
-    test('asListOrEmpty()', () {
-      expect(pick([1, 2, 3]).asListOrEmpty<int>(), [1, 2, 3]);
-      expect(pick('a').asListOrEmpty<int>(), []);
-      expect(nullPick().asListOrEmpty<int>(), []);
-    });
-
-    test('asIntOrNull()', () {
-      expect(pick(1).asIntOrNull(), 1);
-      expect(pick('a').asIntOrNull(), isNull);
-      expect(nullPick().asIntOrNull(), isNull);
-    });
-
-    test('asDoubleOrNull()', () {
-      expect(pick(1).asDoubleOrNull(), 1.0);
-      expect(pick(2.0).asDoubleOrNull(), 2.0);
-      expect(pick('3.0').asDoubleOrNull(), 3.0);
-      expect(pick('a').asDoubleOrNull(), isNull);
-      expect(nullPick().asDoubleOrNull(), isNull);
-    });
-
-    test('asDateTimeOrNull()', () {
-      expect(pick('2012-02-27 13:27:00,123456z').asDateTimeOrNull(),
-          DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
-      expect(pick(DateTime.utc(2020)).asDateTimeOrNull(), DateTime.utc(2020));
-      expect(pick('1').asDateTimeOrNull(), isNull);
-      expect(pick('Bubblegum').asDateTimeOrNull(), isNull);
-      expect(nullPick().asDateTimeOrNull(), isNull);
-    });
-
-    test('asListOrEmpty(Pick -> T)', () {
-      final data = [
-        {'name': 'John Snow'},
-        {'name': 'Daenerys Targaryen'},
-      ];
-      expect(pick(data).asListOrEmpty((it) => Person.fromJson(it.asMap())), [
-        Person(name: 'John Snow'),
-        Person(name: 'Daenerys Targaryen'),
-      ]);
-      expect(pick([]).asList((pick) => Person.fromJson(pick.asMap())), []);
-      expect(nullPick().asListOrEmpty((pick) => Person.fromJson(pick.asMap())),
-          []);
-    });
-
-    test('asListOrEmpty(Pick -> T) reports item parsing errors', () {
-      final data = [
-        {'name': 'John Snow'},
-        {'asdf': 'Daenerys Targaryen'}, // <-- wrong key
-      ];
-      expect(
-          () =>
-              pick(data).asListOrEmpty((pick) => Person.fromJson(pick.asMap())),
-          throwsA(isA<PickException>().having((e) => e.message, 'message',
-              contains('required value at location `name` is absent'))));
-    });
-
-    test('asListOrNull(Pick -> T)', () {
-      final data = [
-        {'name': 'John Snow'},
-        {'name': 'Daenerys Targaryen'},
-      ];
-      expect(pick(data).asListOrNull((pick) => Person.fromJson(pick.asMap())), [
-        Person(name: 'John Snow'),
-        Person(name: 'Daenerys Targaryen'),
-      ]);
-      expect(
-          pick([]).asListOrNull((pick) => Person.fromJson(pick.asMap())), []);
-      expect(nullPick().asListOrNull((pick) => Person.fromJson(pick.asMap())),
-          null);
-    });
-
-    test('asListOrNull(Pick -> T) reports item parsing errors', () {
-      final data = [
-        {'name': 'John Snow'},
-        {'asdf': 'Daenerys Targaryen'}, // <-- wrong key
-      ];
-      expect(
-          () =>
-              pick(data).asListOrNull((pick) => Person.fromJson(pick.asMap())),
-          throwsA(isA<PickException>().having((e) => e.message, 'message',
-              contains('required value at location `name` is absent'))));
     });
   });
 
@@ -336,7 +156,8 @@ void main() {
       expect(root.context, {'lang': 'de'});
     });
 
-    test('add and read from context with syntax sugar', () {
+    test('add and read from context with syntax sugar (deprecated)', () {
+      // ignore: deprecated_member_use_from_same_package
       final root = pick([]).addContext('lang', 'de');
       expect(root.fromContext('lang').asStringOrNull(), 'de');
     });

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -205,26 +205,6 @@ void main() {
       expect(nullPick().asListOrEmpty<int>(), []);
     });
 
-    test('asBoolOrNull()', () {
-      expect(pick(true).asBoolOrNull(), isTrue);
-      expect(pick('a').asBoolOrNull(), isNull);
-      expect(nullPick().asBoolOrNull(), isNull);
-    });
-
-    test('asBoolOrTrue()', () {
-      expect(pick(true).asBoolOrTrue(), isTrue);
-      expect(pick(false).asBoolOrTrue(), isFalse);
-      expect(pick('a').asBoolOrTrue(), isTrue);
-      expect(nullPick().asBoolOrTrue(), isTrue);
-    });
-
-    test('asBoolOrFalse()', () {
-      expect(pick(true).asBoolOrFalse(), isTrue);
-      expect(pick(false).asBoolOrFalse(), isFalse);
-      expect(pick('a').asBoolOrFalse(), isFalse);
-      expect(nullPick().asBoolOrFalse(), isFalse);
-    });
-
     test('asIntOrNull()', () {
       expect(pick(1).asIntOrNull(), 1);
       expect(pick('a').asIntOrNull(), isNull);

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -202,7 +202,7 @@ void main() {
           () => nullPick()
               .required()
               .let((pick) => Person.fromJson(pick.asMap())),
-          throwsA(pickException(containing: ['unknownKey', 'null'])));
+          throwsA(pickException(containing: ['unknownKey', 'absent'])));
     });
 
     test('asList(Pick -> T)', () {

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -31,9 +31,13 @@ void main() {
       expect(pick(1).asString(), '1');
       expect(pick(2.0).asString(), '2.0');
       expect(
-          () => nullPick().asString(),
-          throwsA(pickException(
-              containing: ['unknownKey', 'null', 'String', 'asStringOrNull'])));
+          () => nullPick().asStringOrThrow(),
+          throwsA(pickException(containing: [
+            'unknownKey',
+            'absent',
+            'asStringOrNull',
+            'String'
+          ])));
     });
 
     test("asString() doesn't transform Maps and Lists with toString", () {

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:deep_pick/deep_pick.dart';
 import 'package:test/test.dart';
 
@@ -7,54 +6,14 @@ import 'pick_test.dart';
 void main() {
   group('RequiredPick', () {
     test('toString() works as expected', () {
+      // ignore: deprecated_member_use_from_same_package
       expect(RequiredPick('a', path: ['b', 0]).toString(),
           'RequiredPick(value=a, path=[b, 0])');
     });
-
-    test('pick further', () {
-      final data = [
-        {'name': 'John Snow'},
-        {'name': 'Daenerys Targaryen'},
-      ];
-
-      final first = pick(data, 0).required();
-      expect(first.value, {'name': 'John Snow'});
-
-      // pick further
-      expect(first('name').required().asString(), 'John Snow');
-    });
   });
 
-  group('parsing .required()', () {
-    test('asString()', () {
-      expect(pick('adam').asString(), 'adam');
-      expect(pick(1).asString(), '1');
-      expect(pick(2.0).asString(), '2.0');
-      expect(
-          () => nullPick().asStringOrThrow(),
-          throwsA(pickException(containing: [
-            'unknownKey',
-            'absent',
-            'asStringOrNull',
-            'String'
-          ])));
-    });
-
-    test("asString() doesn't transform Maps and Lists with toString", () {
-      expect(
-          () => pick(['a', 'b']).asString(),
-          throwsA(pickException(
-              containing: ['List<String>', 'not a List or Map', '[a, b]'])));
-      expect(
-          () => pick({'a': 'b'}).asString(),
-          throwsA(pickException(containing: [
-            'Map<String, String>',
-            'not a List or Map',
-            '{a: b}'
-          ])));
-    });
-
-    test('call()', () {
+  group('.call()', () {
+    test('.call() pick further', () {
       final data = [
         {'name': 'John Snow'},
         {'name': 'Daenerys Targaryen'},
@@ -64,7 +23,8 @@ void main() {
       expect(first.value, {'name': 'John Snow'});
 
       // pick further
-      expect(first.call('name').required().asString(), 'John Snow');
+      expect(first.call('name').asStringOrThrow(), 'John Snow');
+      expect(first('name').asStringOrThrow(), 'John Snow');
     });
 
     test('call() carries over the location for good stacktraces', () {
@@ -79,149 +39,6 @@ void main() {
       final level2Pick = level1Pick.call('name');
       expect(level2Pick.path, [0, 'name']);
     });
-
-    test('asMap()', () {
-      expect(pick({'ab': 'cd'}).asMap(), {'ab': 'cd'});
-      expect(
-          () => pick('Bubblegum').asMap(),
-          throwsA(pickException(
-              containing: ['Bubblegum', 'String', 'Map<dynamic, dynamic>'])));
-      expect(
-          () => nullPick().asMap(),
-          throwsA(pickException(
-              containing: ['unknownKey', 'null', 'Map<dynamic, dynamic>'])));
-    });
-
-    test('asMap() throws for cast error', () {
-      final dynamic data = {
-        'a': {'some': 'value'}
-      };
-
-      try {
-        final parsed = pick(data).asMap<String, bool>();
-        fail('casted map without verifying the types. '
-            'Expected Map<String, bool> but was ${parsed.runtimeType}');
-        // ignore: avoid_catching_errors
-      } on TypeError catch (e) {
-        expect(
-          e,
-          const TypeMatcher<TypeError>().having(
-            (e) => e.toString(),
-            'message',
-            stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool']),
-          ),
-        );
-        // ignore: avoid_catching_errors, deprecated_member_use
-      } on CastError catch (e) {
-        // backwards compatibility for Dart 2.7
-        // CastError was replaced with TypeError in Dart 2.8
-        expect(
-          e,
-          // ignore: deprecated_member_use
-          const TypeMatcher<CastError>().having(
-            (e) => e.toString(),
-            'message',
-            stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool']),
-          ),
-        );
-      }
-    });
-
-    test('asList()', () {
-      expect(pick(['a', 'b', 'c']).asList(), ['a', 'b', 'c']);
-      expect(pick([1, 2, 3]).asList<int>(), [1, 2, 3]);
-      expect(
-          () => pick('Bubblegum').asList(),
-          throwsA(pickException(
-              containing: ['Bubblegum', 'String', 'List<dynamic>'])));
-      expect(
-          () => nullPick().asList(),
-          throwsA(pickException(
-              containing: ['unknownKey', 'null', 'List<dynamic>'])));
-      expect(
-          () => nullPick().asList<String>(),
-          throwsA(pickException(
-              containing: ['unknownKey', 'null', 'List<String>'])));
-    });
-
-    test('asBool()', () {
-      expect(pick(true).asBool(), isTrue);
-      expect(pick('true').asBool(), isTrue);
-      expect(pick('false').asBool(), isFalse);
-      expect(() => pick('Bubblegum').asBool(),
-          throwsA(pickException(containing: ['Bubblegum', 'String', 'bool'])));
-      expect(() => nullPick().asBool(),
-          throwsA(pickException(containing: ['unknownKey', 'null', 'bool'])));
-    });
-
-    test('asInt()', () {
-      expect(pick(1).asInt(), 1);
-      expect(pick(1.0).asInt(), 1);
-      expect(pick('1').asInt(), 1);
-      expect(() => pick('Bubblegum').asInt(),
-          throwsA(pickException(containing: ['Bubblegum', 'String', 'int'])));
-      expect(() => nullPick().asInt(),
-          throwsA(pickException(containing: ['unknownKey', 'null', 'int'])));
-    });
-
-    test('asDouble()', () {
-      expect(pick(1).asDouble(), 1.0);
-      expect(pick(2.0).asDouble(), 2.0);
-      expect(pick('3.0').asDouble(), 3.0);
-      expect(
-          () => pick('Bubblegum').asDouble(),
-          throwsA(
-              pickException(containing: ['Bubblegum', 'String', 'double'])));
-      expect(() => nullPick().asDouble(),
-          throwsA(pickException(containing: ['unknownKey', 'null', 'double'])));
-    });
-
-    test('asDateTime()', () {
-      expect(pick('2012-02-27 13:27:00,123456z').asDateTime(),
-          DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
-      expect(
-          () => pick('Bubblegum').asDateTime(),
-          throwsA(
-              pickException(containing: ['Bubblegum', 'String', 'DateTime'])));
-      expect(
-          () => nullPick().asDateTime(),
-          throwsA(
-              pickException(containing: ['unknownKey', 'null', 'DateTime'])));
-    });
-
-    test('let()', () {
-      expect(
-          pick({'name': 'John Snow'})
-              .required()
-              .let((pick) => Person.fromJson(pick.asMap())),
-          Person(name: 'John Snow'));
-      expect(
-          pick({'name': 'John Snow'})
-              .required()
-              .let((pick) => Person.fromJson(pick.asMap())),
-          Person(name: 'John Snow'));
-      expect(
-          () => nullPick()
-              .required()
-              .let((pick) => Person.fromJson(pick.asMap())),
-          throwsA(pickException(containing: ['unknownKey', 'absent'])));
-    });
-
-    test('asList(Pick -> T)', () {
-      final data = [
-        {'name': 'John Snow'},
-        {'name': 'Daenerys Targaryen'},
-      ];
-      expect(pick(data).asList((pick) => Person.fromJson(pick.asMap())), [
-        Person(name: 'John Snow'),
-        Person(name: 'Daenerys Targaryen'),
-      ]);
-      expect(pick([]).asList((pick) => Person.fromJson(pick.asMap())), []);
-      expect(() => nullPick().asList((pick) => Person.fromJson(pick.asMap())),
-          throwsA(pickException(containing: ['unknownKey', 'null', 'List'])));
-    });
   });
 
   group('context API', () {
@@ -235,7 +52,8 @@ void main() {
       expect(root.context, {'lang': 'de'});
     });
 
-    test('add and read from context with syntax sugar', () {
+    test('add and read from context with syntax sugar (deprecated)', () {
+      // ignore: deprecated_member_use_from_same_package
       final root = pick([]).required().addContext('lang', 'de');
       expect(root.fromContext('lang').asStringOrNull(), 'de');
     });
@@ -245,7 +63,7 @@ void main() {
       expect(root.fromContext('user', 'id').asStringOrNull(), '1234');
     });
 
-    test('copy into asList()', () {
+    test('copy context into elements when parsing lists', () {
       final data = [
         {'name': 'John Snow'},
         {'name': 'Daenerys Targaryen'},
@@ -261,7 +79,7 @@ void main() {
       ]);
     });
 
-    test('copy into call() pick', () {
+    test('copy context into call()', () {
       final data = [
         {'name': 'John Snow'},
         {'name': 'Daenerys Targaryen'},


### PR DESCRIPTION
Add `asXyzOrThrow()` methods for all types as shorthad for `.required().asXyz()`.

Refactored tests to have a separate file per parser type

Breaking changes: none