### PR TITLE
Allow parsing of "german" doubles

### DIFF
--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -10,9 +10,40 @@ extension DoublePick on RequiredPick {
       return value.toDouble();
     }
     if (value is String) {
-      final parsed = double.tryParse(value);
+      var parsed = double.tryParse(value);
       if (parsed != null) {
         return parsed;
+      }
+      // remove all spaces
+      final prepared = value.replaceAll(' ', '');
+
+      if (prepared.contains(',') && !prepared.contains('.')) {
+        // Germans use , instead of . as decimal separator
+        // 12,56 -> 12.56
+        parsed = double.tryParse(prepared.replaceAll(',', '.'));
+        if (parsed != null) {
+          return parsed;
+        }
+      }
+
+      // handle digit group separators
+      final firstDot = prepared.indexOf('.');
+      final firstComma = prepared.indexOf(',');
+
+      if (firstDot <= firstComma) {
+        // the germans again
+        // 10.000,00
+        parsed =
+            double.tryParse(prepared.replaceAll('.', '').replaceAll(',', '.'));
+        if (parsed != null) {
+          return parsed;
+        }
+      } else {
+        // 10,000.00
+        parsed = double.tryParse(prepared.replaceAll(',', ''));
+        if (parsed != null) {
+          return parsed;
+        }
       }
     }
     throw PickException('value $value of type ${value.runtimeType} '

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -24,6 +24,17 @@ void main() {
         expect(pick('12345.01').asDoubleOrThrow(), 12345.01);
       });
 
+      test('parse german doubles', () {
+        expect(pick('1,0').asDoubleOrThrow(), 1.0);
+        expect(pick('12345,01').asDoubleOrThrow(), 12345.01);
+      });
+
+      test('parse double with separators', () {
+        expect(pick('12,345.01').asDoubleOrThrow(), 12345.01);
+        expect(pick('12 345,01').asDoubleOrThrow(), 12345.01);
+        expect(pick('12.345,01').asDoubleOrThrow(), 12345.01);
+      });
+
       test('null throws', () {
         expect(
           () => nullPick().asDoubleOrThrow(),


### PR DESCRIPTION
Dart doubles use a dot `.` as decimal separator. But both `,` and `.` are generally accepted as decimal separators for international use. 

This PR allows parsing of more double formats:

```
12345.12
12 345,12
12.345,12
12,345.00

// all map now to double 12345.12
```

