### PR TITLE
Breaking: Don't parse doubles as int

### DIFF
--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -4,17 +4,13 @@ extension IntPick on RequiredPick {
   /// Returns the picked [value] as [int]
   ///
   /// {@template Pick.asInt}
-  /// Parses the picked value as [int]. Other types are parsable as well
-  /// - [String] is gets parsed via [int.tryParse]
-  /// - [double] is gets converted to [int] via [num.toInt()]
+  /// Parses the picked value as [int]. Also tries to parse [String] as [int]
+  /// via [int.tryParse]
   /// {@endtemplate}
   int asInt() {
     final value = this.value;
     if (value is int) {
       return value;
-    }
-    if (value is num) {
-      return value.toInt();
     }
     if (value is String) {
       final parsed = int.tryParse(value);

--- a/test/src/pick_int_test.dart
+++ b/test/src/pick_int_test.dart
@@ -11,10 +11,6 @@ void main() {
         expect(pick(35).asIntOrThrow(), 35);
       });
 
-      test('parse double', () {
-        expect(pick(1.0).asIntOrThrow(), 1);
-      });
-
       test('parse int String', () {
         expect(pick('1').asIntOrThrow(), 1);
         expect(pick('123').asIntOrThrow(), 123);


### PR DESCRIPTION
`asIntOrNull()` shouldn't cast a `double` to `int` because there is never a rounding mechanism with suites a majority. Use `asDoubleOrThrow().toInt()` or `asDoubleOrThrow().round()` and decide on rounding yourself.

