### PR TITLE
Make Pick.isAbsent a getter

### DIFF
--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -76,7 +76,7 @@ void main() {
 
   // access value out of range
   final puma = pick(json, 'shoes', 1);
-  print(puma.isAbsent()); // true;
+  print(puma.isAbsent); // true;
   print(puma.value); // null
 }
 
@@ -106,7 +106,7 @@ class Shoe {
       tags: pick('tags').asListOrEmpty(),
       price: () {
         // when server doesn't send the price field the shoe is not available
-        if (pricePick.isAbsent()) return 'Not for sale';
+        if (pricePick.isAbsent) return 'Not for sale';
         return pricePick.asStringOrNull() ?? 'Price available soon';
       }(),
     );

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -108,15 +108,15 @@ class Pick with PickLocation, PickContext<Pick> {
   /// - Trying to access a key in a [Map] but the found data structure is a [List]
   ///
   /// ```
-  /// pick({"a": null}, "a").isAbsent(); // false
-  /// pick({"a": null}, "b").isAbsent(); // true
+  /// pick({"a": null}, "a").isAbsent; // false
+  /// pick({"a": null}, "b").isAbsent; // true
   ///
-  /// pick([null], 0).isAbsent(); // false
-  /// pick([], 2).isAbsent(); // true
+  /// pick([null], 0).isAbsent; // false
+  /// pick([], 2).isAbsent; // true
   ///
-  /// pick([], "a").isAbsent(); // true
+  /// pick([], "a").isAbsent; // true
   /// ```
-  bool isAbsent() => missingValueAtIndex != null;
+  bool get isAbsent => missingValueAtIndex != null;
 
   @override
   List<dynamic> path;
@@ -162,7 +162,7 @@ class Pick with PickLocation, PickContext<Pick> {
       final more = fromContext(requiredPickErrorHintKey).value as String?;
       final moreSegment = more == null ? '' : ' $more';
       throw PickException('required value at location ${location()} '
-          'is ${isAbsent() ? 'absent' : 'null'}.$moreSegment');
+          'is ${isAbsent ? 'absent' : 'null'}.$moreSegment');
     }
     return RequiredPick(value, path: path, context: _context);
   }

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -54,8 +54,10 @@ void main() {
     });
 
     test('deprecated asDouble forwards to asDoubleOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
       expect(pick('1').asDouble(), 1.0);
       expect(
+        // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).asDouble(),
         throwsA(pickException(containing: [
           "value Instance of 'Object' of type Object at location `<root>` can not be parsed as double"

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -11,6 +11,7 @@ void main() {
 
     test('toString() prints value and path', () {
       expect(
+        // ignore: deprecated_member_use_from_same_package
         Pick('a', path: ['b', 0]).toString(),
         'Pick(value=a, path=[b, 0])',
       );
@@ -61,32 +62,32 @@ void main() {
       expect(level2Pick.path, [0, 'name']);
     });
 
-    group('isAbsent()', () {
+    group('isAbsent', () {
       test('is not absent because value', () {
         final p = pick('a');
         expect(p.value, isNotNull);
-        expect(p.isAbsent(), isFalse);
+        expect(p.isAbsent, isFalse);
         expect(p.missingValueAtIndex, null);
       });
 
       test('is not absent but null', () {
         final p = pick(null);
         expect(p.value, isNull);
-        expect(p.isAbsent(), isFalse);
+        expect(p.isAbsent, isFalse);
         expect(p.missingValueAtIndex, null);
       });
 
       test('is not absent but null further down', () {
         final p = pick({'a': null}, 'a');
         expect(p.value, isNull);
-        expect(p.isAbsent(), isFalse);
+        expect(p.isAbsent, isFalse);
         expect(p.missingValueAtIndex, null);
       });
 
       test('is not absent, not null', () {
         final p = pick({'a', 1}, 'b');
         expect(p.value, isNull);
-        expect(p.isAbsent(), isTrue);
+        expect(p.isAbsent, isTrue);
         expect(p.missingValueAtIndex, 0);
       });
 
@@ -96,7 +97,7 @@ void main() {
         };
         final p = pick(json, 'a', 'x' /*absent*/);
         expect(p.value, isNull);
-        expect(p.isAbsent(), isTrue);
+        expect(p.isAbsent, isTrue);
         expect(p.missingValueAtIndex, 1);
       });
     });
@@ -109,39 +110,39 @@ void main() {
         {'name': 'Daenerys Targaryen'},
       ];
       expect(pick(data, 10).value, isNull);
-      expect(pick(data, 10).isAbsent(), true);
+      expect(pick(data, 10).isAbsent, true);
     });
 
     test('unknown property in map returns null', () {
       final data = {'name': 'John Snow'};
       expect(pick(data, 'birthday').value, isNull);
-      expect(pick(data, 'birthday').isAbsent(), true);
+      expect(pick(data, 'birthday').isAbsent, true);
     });
 
     test('documentation example Map', () {
       final pa = pick({'a': null}, 'a');
       expect(pa.value, isNull);
-      expect(pa.isAbsent(), false);
+      expect(pa.isAbsent, false);
 
       final pb = pick({'a': null}, 'b');
       expect(pb.value, isNull);
-      expect(pb.isAbsent(), true);
+      expect(pb.isAbsent, true);
     });
 
     test('documentation example List', () {
       final p0 = pick([null], 0);
       expect(p0.value, isNull);
-      expect(p0.isAbsent(), false);
+      expect(p0.isAbsent, false);
 
       final p2 = pick([], 2);
       expect(p2.value, isNull);
-      expect(p2.isAbsent(), true);
+      expect(p2.isAbsent, true);
     });
 
     test('Map key for list', () {
       final p = pick([], 'a');
       expect(p.value, isNull);
-      expect(p.isAbsent(), true);
+      expect(p.isAbsent, true);
     });
   });
 

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -1,8 +1,6 @@
 import 'package:deep_pick/deep_pick.dart';
 import 'package:test/test.dart';
 
-import 'pick_test.dart';
-
 void main() {
   group('RequiredPick', () {
     test('toString() works as expected', () {


### PR DESCRIPTION
Followup to #24

Picks are immutable, a getter fits better because the value never changes

Breaking, but no version with `isAbsent()` as method was released