### PR TITLE
Acknowledge that all parsers can fail

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -45,5 +45,6 @@ jobs:
       run: pub get --no-precompile
     - name: lint
       run: dartanalyzer .
-    - name: Verify package completness
-      run: pub publish -n
+    # TODO enable when 2.12 is published to overcome or this is fixed https://github.com/dart-lang/pub/issues/2535
+    #- name: Verify package completness
+    #  run: pub publish -n

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.0
+
+- Removal of parsing extensions of `RequiredPick` to acknowledge that parsing causes errors too. Read more in [#34](https://github.com/passsy/deep_pick/pull/34)
+- Replace `dynamic` with `Object` where possible
+
 ## 0.7.0
 
 - Enable nullsafety (requires Dart >=2.12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## 0.8.0
 
-- Removal of parsing extensions of `RequiredPick` to acknowledge that parsing causes errors too. Read more in [#34](https://github.com/passsy/deep_pick/pull/34)
+- Deprecated parsing extensions of `RequiredPick` to acknowledge that all parsers eventually causes errors. 
+  From now on, always use `.asIntOrThrow()` instead of `.required().asInt()`. Only exception is `.required().toString()`.
+  Read more in [#34](https://github.com/passsy/deep_pick/pull/34)
 - Replace `dynamic` with `Object` where possible
+- Rename `Pick.location()` to `Pick.debugParsingExit`
+- Removal of `PickLocaiton` and `PickContext` mixins. They are now part of `Pick`
+- `RequiredPick` now extends `Pick` making it easier to write parsers for custom types
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ This example parses a `int` as Firestore `Timestamp`.
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:deep_pick/deep_pick.dart';
 
-extension TimestampPick on RequiredPick {
-  Timestamp asFirestoreTimeStamp() {
-    final value = this.value;
+extension NullableTimestampPick on Pick {
+  Timestamp asFirestoreTimeStampOrThrow() {
+    final value = required().value;
     if (value is Timestamp) {
       return value;
     }
@@ -247,17 +247,11 @@ extension TimestampPick on RequiredPick {
     throw PickException(
         "value $value of type ${value.runtimeType} at location ${location()} can't be casted to Timestamp");
   }
-}
-
-extension NullableTimestampPick on Pick {
-  Timestamp asFirestoreTimeStampOrThrow() {
-    return required().asFirestoreTimeStamp();
-  }
 
   Timestamp? asFirestoreTimeStampOrNull() {
     if (value == null) return null;
     try {
-      return required().asFirestoreTimeStamp();
+      return asFirestoreTimeStampOrThrow();
     } catch (_) {
       return null;
     }

--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -44,8 +44,8 @@ Future<void> main() async {
   print(id.asStringOrNull()); // "421"
 
   // pick lists
-  final tags =
-      pick(json, 'shoes', 0, 'tags').asListOrEmpty((it) => it.asStringOrThrow());
+  final tags = pick(json, 'shoes', 0, 'tags')
+      .asListOrEmpty((it) => it.asStringOrThrow());
   print(tags); // [nike, JustDoIt]
 
   // pick maps

--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -38,7 +38,7 @@ Future<void> main() async {
   print(manufacturer); // null
 
   // use required() to crash if a object doesn't exist
-  final name = pick(json, 'shoes', 0, 'name').required().asString();
+  final name = pick(json, 'shoes', 0, 'name').required().asStringOrThrow();
   print(name); // Nike Zoom Fly 3
 
   // you decide which type you want
@@ -49,11 +49,11 @@ Future<void> main() async {
 
   // pick lists
   final tags =
-      pick(json, 'shoes', 0, 'tags').asListOrEmpty((it) => it.asString());
+      pick(json, 'shoes', 0, 'tags').asListOrEmpty((it) => it.asStringOrThrow());
   print(tags); // [nike, JustDoIt]
 
   // pick maps
-  final shoe = pick(json, 'shoes', 0).required().asMap();
+  final shoe = pick(json, 'shoes', 0).required().asMapOrThrow();
   print(shoe); // {id: 421, name: Nike Zoom Fly 3, tags: [nike, JustDoIt]}
 
   // easily pick and map objects to dart objects
@@ -107,13 +107,13 @@ class Shoe {
     final newApi = pick.fromContext('newApi').asBoolOrFalse();
     final pricePick = pick('price');
     return Shoe(
-      id: pick('id').required().asString(),
-      name: pick('name').required().asString(),
+      id: pick('id').asStringOrThrow(),
+      name: pick('name').asStringOrThrow(),
       // manufacturer is a required field in the new API
       manufacturer: newApi
-          ? pick('manufacturer').required().asString()
+          ? pick('manufacturer').asStringOrThrow()
           : pick('manufacturer').asStringOrNull(),
-      tags: pick('tags').asListOrEmpty((it) => it.asString()),
+      tags: pick('tags').asListOrEmpty((it) => it.asStringOrThrow()),
       price: () {
         // when server doesn't send the price field the shoe is not available
         if (pricePick.isAbsent) return 'Not for sale';

--- a/example/deep_pick_example.dart
+++ b/example/deep_pick_example.dart
@@ -25,7 +25,7 @@ Future<void> main() async {
 }
 ''');
 
-  // pick a value deep down the json structure
+  // pick a value deep down the json structure or crash
   final firstTag = pick(json, 'shoes', 1, 'tags', 0).asStringOrThrow();
   print(firstTag); // adidas
 
@@ -36,10 +36,6 @@ Future<void> main() async {
   // fallback to null if it couldn't be found
   final manufacturer = pick(json, 'shoes', 0, 'manufacturer').asStringOrNull();
   print(manufacturer); // null
-
-  // use required() to crash if a object doesn't exist
-  final name = pick(json, 'shoes', 0, 'name').required().asStringOrThrow();
-  print(name); // Nike Zoom Fly 3
 
   // you decide which type you want
   final id = pick(json, 'shoes', 0, 'id');

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -159,9 +159,9 @@ class Pick with PickLocation, PickContext<Pick> {
   final Map<String, Object?> _context;
 
   /// Enter a "required" context which requires the picked value to be non-null
-  /// and parsable or a [PickException] is thrown.
+  /// or a [PickException] is thrown.
   ///
-  /// Crashes when the the value is `null` or can't be parsed correctly with the asXyz() methods.
+  /// Crashes when the the value is `null`.
   RequiredPick required() {
     final value = this.value;
     if (value == null) {
@@ -182,61 +182,23 @@ class Pick with PickLocation, PickContext<Pick> {
 }
 
 /// A picked object holding the [value] (never null) and giving access to useful parsing functions
-class RequiredPick with PickLocation, PickContext<RequiredPick> {
+class RequiredPick extends Pick {
   RequiredPick(
     // using dynamic here to match the return type of jsonDecode
     dynamic value, {
-    this.path = const [],
+    List<Object> path = const [],
     Map<String, Object?>? context,
   })  : value = value as Object,
-        _context = context != null ? Map.of(context) : {};
+        super(value, path: path, context: context);
 
-  /// The picked value, never `null`
+  @override
+  // ignore: overridden_fields
   final Object value;
-
-  @override
-  List<Object> path;
-
-  @override
-  List<Object> get followablePath => path;
-
-  // Pick even further
-  Pick call([
-    Object? arg0,
-    Object? arg1,
-    Object? arg2,
-    Object? arg3,
-    Object? arg4,
-    Object? arg5,
-    Object? arg6,
-    Object? arg7,
-    Object? arg8,
-    Object? arg9,
-  ]) {
-    final selectors =
-        [arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]
-            // null is a sign for unused 'varargs'
-            .where((Object? it) => it != null)
-            .cast<Object>()
-            .toList(growable: false);
-
-    return _drillDown(value, selectors, parentPath: path, context: context);
-  }
-
-  @override
-  Map<String, Object?> get context => _context;
-  final Map<String, Object?> _context;
 
   @override
   @Deprecated('Use asStringOrNull() to pick a String value')
   String toString() => 'RequiredPick(value=$value, path=$path)';
 
-  @override
-  RequiredPick get _builder => this;
-
-  /// Converts the picked value to a nullable type [Pick]
-  ///
-  /// Inverse of [Pick.required]
   Pick nullable() => Pick(value, path: path, context: context);
 }
 

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -303,7 +303,8 @@ class RequiredPick extends Pick {
   // Has been removed in 0.5.0
   @Deprecated('Use withContext')
   @override
-  RequiredPick Function(String key, dynamic value) get addContext => withContext;
+  RequiredPick Function(String key, dynamic value) get addContext =>
+      withContext;
 
   @override
   RequiredPick withContext(String key, Object? value) {

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -193,7 +193,7 @@ class RequiredPick extends Pick {
 
   @override
   // ignore: overridden_fields
-  final Object value;
+  covariant Object value;
 
   @override
   @Deprecated('Use asStringOrNull() to pick a String value')

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -1,7 +1,7 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension BoolPick on Pick {
-  bool _asBool() {
+  bool _parse() {
     final value = this.value;
     if (value is bool) {
       return value;
@@ -20,13 +20,13 @@ extension BoolPick on Pick {
   bool asBoolOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asBoolOrNull() when the value may be null/absent at some point (bool?).');
-    return required()._asBool();
+    return required()._parse();
   }
 
   bool? asBoolOrNull() {
     if (value == null) return null;
     try {
-      return required()._asBool();
+      return required()._parse();
     } catch (_) {
       return null;
     }
@@ -35,7 +35,7 @@ extension BoolPick on Pick {
   bool asBoolOrTrue() {
     if (value == null) return true;
     try {
-      return required()._asBool();
+      return required()._parse();
     } catch (_) {
       return true;
     }
@@ -44,7 +44,7 @@ extension BoolPick on Pick {
   bool asBoolOrFalse() {
     if (value == null) return false;
     try {
-      return required()._asBool();
+      return required()._parse();
     } catch (_) {
       return false;
     }

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -1,6 +1,26 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension BoolPick on Pick {
+  /// Returns the picked [value] as [bool]
+  ///
+  /// {@template Pick.asBool}
+  /// Only the exact Strings "true" and "false" are valid boolean
+  /// representations. Other concepts of booleans such as `1` and `0`,
+  /// or "YES" and "NO" are not supported.
+  ///
+  /// Use `.let()` to parse those custom representations
+  /// ```dart
+  /// pick(1).letOrNull((pick) {
+  ///    if (pick.value == 1) {
+  ///      return true;
+  ///    }
+  ///    if (pick.value == 0) {
+  ///      return false;
+  ///    }
+  ///    return null;
+  ///  });
+  /// ```
+  /// {@endtemplate}
   bool _parse() {
     final value = this.value;
     if (value is bool) {
@@ -17,12 +37,19 @@ extension BoolPick on Pick {
   @Deprecated('Use .asBoolOrThrow()')
   bool Function() get asBool => asBoolOrThrow;
 
+  /// Returns the picked [value] as [bool] or throws a [PickException]
+  ///
+  /// {@macro Pick.asBool}
   bool asBoolOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asBoolOrNull() when the value may be null/absent at some point (bool?).');
     return required()._parse();
   }
 
+  /// Returns the picked [value] as [bool] or `null` if it can't be interpreted
+  /// as [bool].
+  ///
+  /// {@macro Pick.asBool}
   bool? asBoolOrNull() {
     if (value == null) return null;
     try {
@@ -32,6 +59,10 @@ extension BoolPick on Pick {
     }
   }
 
+  /// Returns the picked [value] as [bool] or defaults to `true` when the
+  /// [value] is `null` or can't be interpreted as [bool].
+  ///
+  /// {@macro Pick.asBool}
   bool asBoolOrTrue() {
     if (value == null) return true;
     try {
@@ -41,6 +72,10 @@ extension BoolPick on Pick {
     }
   }
 
+  /// Returns the picked [value] as [bool] or defaults to `false` when the
+  /// [value] is `null` or can't be interpreted as [bool].
+  ///
+  /// {@macro Pick.asBool}
   bool asBoolOrFalse() {
     if (value == null) return false;
     try {

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -30,8 +30,8 @@ extension BoolPick on Pick {
       if (value == 'true') return true;
       if (value == 'false') return false;
     }
-    throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be casted to bool');
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be casted to bool');
   }
 
   @Deprecated('Use .asBoolOrThrow()')

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -22,7 +22,7 @@ extension BoolPick on Pick {
   /// ```
   /// {@endtemplate}
   bool _parse() {
-    final value = this.value;
+    final value = required().value;
     if (value is bool) {
       return value;
     }
@@ -43,7 +43,7 @@ extension BoolPick on Pick {
   bool asBoolOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asBoolOrNull() when the value may be null/absent at some point (bool?).');
-    return required()._parse();
+    return _parse();
   }
 
   /// Returns the picked [value] as [bool] or `null` if it can't be interpreted
@@ -53,7 +53,7 @@ extension BoolPick on Pick {
   bool? asBoolOrNull() {
     if (value == null) return null;
     try {
-      return required()._parse();
+      return _parse();
     } catch (_) {
       return null;
     }
@@ -66,7 +66,7 @@ extension BoolPick on Pick {
   bool asBoolOrTrue() {
     if (value == null) return true;
     try {
-      return required()._parse();
+      return _parse();
     } catch (_) {
       return true;
     }
@@ -79,7 +79,7 @@ extension BoolPick on Pick {
   bool asBoolOrFalse() {
     if (value == null) return false;
     try {
-      return required()._parse();
+      return _parse();
     } catch (_) {
       return false;
     }

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -1,6 +1,5 @@
 import 'package:deep_pick/src/pick.dart';
 
-
 extension BoolPick on Pick {
   bool _asBool() {
     final value = this.value;

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -1,7 +1,8 @@
 import 'package:deep_pick/src/pick.dart';
 
-extension BoolPick on RequiredPick {
-  bool asBool() {
+
+extension BoolPick on Pick {
+  bool _asBool() {
     final value = this.value;
     if (value is bool) {
       return value;
@@ -13,22 +14,20 @@ extension BoolPick on RequiredPick {
     throw PickException('value $value of type ${value.runtimeType} '
         'at location ${location()} can not be casted to bool');
   }
-}
 
-extension NullableBoolPick on Pick {
   @Deprecated('Use .asBoolOrThrow()')
   bool Function() get asBool => asBoolOrThrow;
 
   bool asBoolOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asBoolOrNull() when the value may be null/absent at some point (bool?).');
-    return required().asBool();
+    return required()._asBool();
   }
 
   bool? asBoolOrNull() {
     if (value == null) return null;
     try {
-      return required().asBool();
+      return required()._asBool();
     } catch (_) {
       return null;
     }
@@ -37,7 +36,7 @@ extension NullableBoolPick on Pick {
   bool asBoolOrTrue() {
     if (value == null) return true;
     try {
-      return required().asBool();
+      return required()._asBool();
     } catch (_) {
       return true;
     }
@@ -46,7 +45,7 @@ extension NullableBoolPick on Pick {
   bool asBoolOrFalse() {
     if (value == null) return false;
     try {
-      return required().asBool();
+      return required()._asBool();
     } catch (_) {
       return false;
     }

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -1,6 +1,5 @@
 import 'package:deep_pick/src/pick.dart';
 
-
 extension NullableDateTimePick on Pick {
   @Deprecated('Use .asDateTimeOrThrow()')
   DateTime Function() get asDateTime => asDateTimeOrThrow;

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -1,6 +1,10 @@
 import 'package:deep_pick/src/pick.dart';
 
-extension DateTimePick on RequiredPick {
+
+extension NullableDateTimePick on Pick {
+  @Deprecated('Use .asDateTimeOrThrow()')
+  DateTime Function() get asDateTime => asDateTimeOrThrow;
+
   /// Parses the picked non-null [value] as [DateTime] or throws
   ///
   /// {@template Pick.asDateTime}
@@ -18,7 +22,7 @@ extension DateTimePick on RequiredPick {
   /// - `'-123450101 00:00:00 Z'`: in the year -12345.
   /// - `'2002-02-27T14:00:00-0500'`: Same as `'2002-02-27T19:00:00Z'`
   /// {@endtemplate}
-  DateTime asDateTime() {
+  DateTime _parse() {
     final value = this.value;
     if (value is DateTime) {
       return value;
@@ -32,11 +36,6 @@ extension DateTimePick on RequiredPick {
     throw PickException('value $value of type ${value.runtimeType} '
         'at location ${location()} can not be parsed as DateTime');
   }
-}
-
-extension NullableDateTimePick on Pick {
-  @Deprecated('Use .asDateTimeOrThrow()')
-  DateTime Function() get asDateTime => asDateTimeOrThrow;
 
   /// Parses the picked [value] as [DateTime] or throws
   ///
@@ -46,7 +45,7 @@ extension NullableDateTimePick on Pick {
   DateTime asDateTimeOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).');
-    return required().asDateTime();
+    return required()._parse();
   }
 
   /// Parses the picked [value] as [DateTime] or returns `null`
@@ -55,7 +54,7 @@ extension NullableDateTimePick on Pick {
   DateTime? asDateTimeOrNull() {
     if (value == null) return null;
     try {
-      return required().asDateTime();
+      return _parse();
     } catch (_) {
       return null;
     }

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -32,8 +32,8 @@ extension NullableDateTimePick on Pick {
         return dateTime;
       }
     }
-    throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be parsed as DateTime');
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be parsed as DateTime');
   }
 
   /// Parses the picked [value] as [DateTime] or throws

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -22,7 +22,7 @@ extension NullableDateTimePick on Pick {
   /// - `'2002-02-27T14:00:00-0500'`: Same as `'2002-02-27T19:00:00Z'`
   /// {@endtemplate}
   DateTime _parse() {
-    final value = this.value;
+    final value = required().value;
     if (value is DateTime) {
       return value;
     }
@@ -44,7 +44,7 @@ extension NullableDateTimePick on Pick {
   DateTime asDateTimeOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).');
-    return required()._parse();
+    return _parse();
   }
 
   /// Parses the picked [value] as [DateTime] or returns `null`

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -49,8 +49,8 @@ extension NullableDoublePick on Pick {
         }
       }
     }
-    throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be parsed as double');
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be parsed as double');
   }
 
   double asDoubleOrThrow() {

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -5,7 +5,7 @@ extension NullableDoublePick on Pick {
   double Function() get asDouble => asDoubleOrThrow;
 
   double _parse() {
-    final value = this.value;
+    final value = required().value;
     if (value is double) {
       return value;
     }
@@ -56,7 +56,7 @@ extension NullableDoublePick on Pick {
   double asDoubleOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asDoubleOrNull() when the value may be null/absent at some point (double?).');
-    return required()._parse();
+    return _parse();
   }
 
   double? asDoubleOrNull() {

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -1,7 +1,11 @@
 import 'package:deep_pick/src/pick.dart';
 
-extension DoublePick on RequiredPick {
-  double asDouble() {
+
+extension NullableDoublePick on Pick {
+  @Deprecated('Use .asDoubleOrThrow()')
+  double Function() get asDouble => asDoubleOrThrow;
+
+  double _parse() {
     final value = this.value;
     if (value is double) {
       return value;
@@ -49,22 +53,17 @@ extension DoublePick on RequiredPick {
     throw PickException('value $value of type ${value.runtimeType} '
         'at location ${location()} can not be parsed as double');
   }
-}
-
-extension NullableDoublePick on Pick {
-  @Deprecated('Use .asDoubleOrThrow()')
-  double Function() get asDouble => asDoubleOrThrow;
 
   double asDoubleOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asDoubleOrNull() when the value may be null/absent at some point (double?).');
-    return required().asDouble();
+    return required()._parse();
   }
 
   double? asDoubleOrNull() {
     if (value == null) return null;
     try {
-      return required().asDouble();
+      return _parse();
     } catch (_) {
       return null;
     }

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -1,6 +1,5 @@
 import 'package:deep_pick/src/pick.dart';
 
-
 extension NullableDoublePick on Pick {
   @Deprecated('Use .asDoubleOrThrow()')
   double Function() get asDouble => asDoubleOrThrow;

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -21,8 +21,8 @@ extension NullableIntPick on Pick {
         return parsed;
       }
     }
-    throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be parsed as int');
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be parsed as int');
   }
 
   /// Returns the picked [value] as [int] or throws

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -11,7 +11,7 @@ extension NullableIntPick on Pick {
   /// via [int.tryParse]
   /// {@endtemplate}
   int _parse() {
-    final value = this.value;
+    final value = required().value;
     if (value is int) {
       return value;
     }
@@ -31,7 +31,7 @@ extension NullableIntPick on Pick {
   int asIntOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asIntOrNull() when the value may be null/absent at some point (int?).');
-    return required()._parse();
+    return _parse();
   }
 
   /// Returns the picked [value] as [int?] or returns `null` when the picked

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -1,13 +1,16 @@
 import 'package:deep_pick/src/pick.dart';
 
-extension IntPick on RequiredPick {
+extension NullableIntPick on Pick {
+  @Deprecated('Use .asIntOrThrow()')
+  int Function() get asInt => asIntOrThrow;
+
   /// Returns the picked [value] as [int]
   ///
   /// {@template Pick.asInt}
   /// Parses the picked value as [int]. Also tries to parse [String] as [int]
   /// via [int.tryParse]
   /// {@endtemplate}
-  int asInt() {
+  int _parse() {
     final value = this.value;
     if (value is int) {
       return value;
@@ -21,11 +24,6 @@ extension IntPick on RequiredPick {
     throw PickException('value $value of type ${value.runtimeType} '
         'at location ${location()} can not be parsed as int');
   }
-}
-
-extension NullableIntPick on Pick {
-  @Deprecated('Use .asIntOrThrow()')
-  int Function() get asInt => asIntOrThrow;
 
   /// Returns the picked [value] as [int] or throws
   ///
@@ -33,7 +31,7 @@ extension NullableIntPick on Pick {
   int asIntOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asIntOrNull() when the value may be null/absent at some point (int?).');
-    return required().asInt();
+    return required()._parse();
   }
 
   /// Returns the picked [value] as [int?] or returns `null` when the picked
@@ -43,7 +41,7 @@ extension NullableIntPick on Pick {
   int? asIntOrNull() {
     if (value == null) return null;
     try {
-      return required().asInt();
+      return _parse();
     } catch (_) {
       return null;
     }

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -1,6 +1,5 @@
 import 'package:deep_pick/src/pick.dart';
 
-
 extension NullableListPick on Pick {
   @Deprecated('Use .asListOrThrow()')
   List<T> asList<T>([T Function(Pick)? map]) {
@@ -20,7 +19,7 @@ extension NullableListPick on Pick {
         index++;
         if (item != null) {
           final picked =
-          RequiredPick(item, path: [...path, index], context: context);
+              RequiredPick(item, path: [...path, index], context: context);
           result.add(map(picked));
           continue;
         }

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -34,14 +34,14 @@ extension NullableListPick on Pick {
         } catch (e) {
           // ignore: avoid_print
           print(
-              'whenNull at location ${location()} index: $index crashed instead of returning a $T');
+              'whenNull at location $debugParsingExit index: $index crashed instead of returning a $T');
           rethrow;
         }
       }
       return result;
     }
-    throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be casted to List<dynamic>');
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be casted to List<dynamic>');
   }
 
   List<T> asListOrThrow<T>(T Function(RequiredPick) map,

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -11,7 +11,7 @@ extension NullableListPick on Pick {
 
   List<T> _parse<T>(T Function(RequiredPick) map,
       {T Function(Pick pick)? whenNull}) {
-    final value = this.value;
+    final value = required().value;
     if (value is List) {
       final result = <T>[];
       var index = -1;
@@ -48,7 +48,7 @@ extension NullableListPick on Pick {
       {T Function(Pick pick)? whenNull}) {
     withContext(requiredPickErrorHintKey,
         'Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<$T>?).');
-    return required()._parse(map, whenNull: whenNull);
+    return _parse(map, whenNull: whenNull);
   }
 
   List<T> asListOrEmpty<T>(T Function(RequiredPick) map,

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -1,7 +1,10 @@
 import 'package:deep_pick/src/pick.dart';
 
-extension MapPick on RequiredPick {
-  Map<RK, RV> asMap<RK, RV>() {
+extension NullableMapPick on Pick {
+  @Deprecated('Use .asMapOrThrow()')
+  Map<RK, RV> Function<RK, RV>() get asMap => asMapOrThrow;
+
+  Map<RK, RV> _parse<RK, RV>() {
     final value = this.value;
     if (value is Map) {
       final view = value.cast<RK, RV>();
@@ -12,27 +15,22 @@ extension MapPick on RequiredPick {
     throw PickException('value $value of type ${value.runtimeType} '
         'at location ${location()} can not be casted to Map<dynamic, dynamic>');
   }
-}
-
-extension NullableMapPick on Pick {
-  @Deprecated('Use .asMapOrThrow()')
-  Map<RK, RV> Function<RK, RV>() get asMap => asMapOrThrow;
 
   Map<RK, RV> asMapOrThrow<RK, RV>() {
     withContext(requiredPickErrorHintKey,
         'Use asMapOrEmpty()/asMapOrNull() when the value may be null/absent at some point (Map<$RK, $RV>?).');
-    return required().asMap();
+    return required()._parse();
   }
 
   Map<RK, RV> asMapOrEmpty<RK, RV>() {
     if (value == null) return <RK, RV>{};
     if (value is! Map) return <RK, RV>{};
-    return required().asMap();
+    return _parse();
   }
 
   Map<RK, RV>? asMapOrNull<RK, RV>() {
     if (value == null) return null;
     if (value is! Map) return null;
-    return required().asMap();
+    return _parse();
   }
 }

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -12,8 +12,8 @@ extension NullableMapPick on Pick {
       // and not lazily type checked when accessing them
       return Map.of(view);
     }
-    throw PickException('value $value of type ${value.runtimeType} '
-        'at location ${location()} can not be casted to Map<dynamic, dynamic>');
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be casted to Map<dynamic, dynamic>');
   }
 
   Map<RK, RV> asMapOrThrow<RK, RV>() {

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -5,7 +5,7 @@ extension NullableMapPick on Pick {
   Map<RK, RV> Function<RK, RV>() get asMap => asMapOrThrow;
 
   Map<RK, RV> _parse<RK, RV>() {
-    final value = this.value;
+    final value = required().value;
     if (value is Map) {
       final view = value.cast<RK, RV>();
       // create copy of casted view so all items are type checked here
@@ -19,7 +19,7 @@ extension NullableMapPick on Pick {
   Map<RK, RV> asMapOrThrow<RK, RV>() {
     withContext(requiredPickErrorHintKey,
         'Use asMapOrEmpty()/asMapOrNull() when the value may be null/absent at some point (Map<$RK, $RV>?).');
-    return required()._parse();
+    return _parse();
   }
 
   Map<RK, RV> asMapOrEmpty<RK, RV>() {

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -1,6 +1,5 @@
 import 'package:deep_pick/src/pick.dart';
 
-
 extension NullableStringPick on Pick {
   @Deprecated('Use .asStringOrThrow()')
   String Function() get asString => asStringOrThrow;
@@ -22,8 +21,8 @@ extension NullableStringPick on Pick {
     if (value is List || value is Map) {
       throw PickException(
           'value at location ${location()} is of type ${value.runtimeType}. '
-              'Drill further down to a value which is not a List or Map. '
-              'value: $value');
+          'Drill further down to a value which is not a List or Map. '
+          'value: $value');
     }
     return value.toString();
   }

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -7,27 +7,20 @@ extension NullableStringPick on Pick {
   /// Returns the picked [value] as [String] representation
   ///
   /// {@template Pick.asString}
-  /// Parses the picked value as String. If the value is not already a [String]
+  /// Parses the picked [value] as String. If the value is not already a [String]
   /// its [Object.toString()] will be called. This means that this method works
-  /// for [int], [double] and any other [Object] which isn't a collection of
-  /// values such as a [List] or [Map]
+  /// for [int], [double] and any other [Object].
   /// {@endtemplate}
   String _parse() {
     final value = this.value;
     if (value is String) {
       return value;
     }
-    if (value is List || value is Map) {
-      throw PickException(
-          'value at location ${location()} is of type ${value.runtimeType}. '
-          'Drill further down to a value which is not a List or Map. '
-          'value: $value');
-    }
     return value.toString();
   }
 
   /// Returns the picked [value] as String representation; only throws a
-  /// [PickException] when the value is `null`.
+  /// [PickException] when the value is `null` or [isAbsent].
   ///
   /// {@macro Pick.asString}
   String asStringOrThrow() {

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -19,7 +19,7 @@ extension NullableStringPick on Pick {
   /// for [int], [double] and any other [Object].
   /// {@endtemplate}
   String _parse() {
-    final value = this.value;
+    final value = required().value;
     if (value is String) {
       return value;
     }
@@ -33,7 +33,7 @@ extension NullableStringPick on Pick {
   String asStringOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asStringOrNull() when the value may be null/absent at some point (String?).');
-    return required()._parse();
+    return _parse();
   }
 
   /// Returns the picked [value] as [String] or returns `null` when the picked value isn't available

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -1,5 +1,12 @@
 import 'package:deep_pick/src/pick.dart';
 
+extension RequiredStringPick on RequiredPick {
+  /// Returns the picked [value] as [String] representation
+  ///
+  /// {@macro Pick.asString}
+  String asString() => _parse();
+}
+
 extension NullableStringPick on Pick {
   @Deprecated('Use .asStringOrThrow()')
   String Function() get asString => asStringOrThrow;

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -1,6 +1,10 @@
 import 'package:deep_pick/src/pick.dart';
 
-extension StringPick on RequiredPick {
+
+extension NullableStringPick on Pick {
+  @Deprecated('Use .asStringOrThrow()')
+  String Function() get asString => asStringOrThrow;
+
   /// Returns the picked [value] as String representation; only throws when
   /// the value is `null`.
   ///
@@ -10,7 +14,7 @@ extension StringPick on RequiredPick {
   /// for [int], [double] and any other [Object] which isn't a collection of
   /// values such as a [List] or [Map]
   /// {@endtemplate}
-  String asString() {
+  String _parse() {
     final value = this.value;
     if (value is String) {
       return value;
@@ -18,16 +22,11 @@ extension StringPick on RequiredPick {
     if (value is List || value is Map) {
       throw PickException(
           'value at location ${location()} is of type ${value.runtimeType}. '
-          'Drill further down to a value which is not a List or Map. '
-          'value: $value');
+              'Drill further down to a value which is not a List or Map. '
+              'value: $value');
     }
     return value.toString();
   }
-}
-
-extension NullableStringPick on Pick {
-  @Deprecated('Use .asStringOrThrow()')
-  String Function() get asString => asStringOrThrow;
 
   /// Returns the picked [value] as String representation; only throws when
   /// the value is `null`.
@@ -36,7 +35,7 @@ extension NullableStringPick on Pick {
   String asStringOrThrow() {
     withContext(requiredPickErrorHintKey,
         'Use asStringOrNull() when the value may be null/absent at some point (String?).');
-    return required().asString();
+    return required()._parse();
   }
 
   /// Returns the picked [value] as [String] or returns `null` when the picked value isn't available
@@ -45,7 +44,7 @@ extension NullableStringPick on Pick {
   String? asStringOrNull() {
     if (value == null) return null;
     try {
-      return required().asString();
+      return _parse();
     } catch (_) {
       return null;
     }

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -4,8 +4,7 @@ extension NullableStringPick on Pick {
   @Deprecated('Use .asStringOrThrow()')
   String Function() get asString => asStringOrThrow;
 
-  /// Returns the picked [value] as String representation; only throws when
-  /// the value is `null`.
+  /// Returns the picked [value] as [String] representation
   ///
   /// {@template Pick.asString}
   /// Parses the picked value as String. If the value is not already a [String]
@@ -27,8 +26,8 @@ extension NullableStringPick on Pick {
     return value.toString();
   }
 
-  /// Returns the picked [value] as String representation; only throws when
-  /// the value is `null`.
+  /// Returns the picked [value] as String representation; only throws a
+  /// [PickException] when the value is `null`.
   ///
   /// {@macro Pick.asString}
   String asStringOrThrow() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deep_pick
 description: Simplifies manual JSON parsing with a type-safe API. No dynamic, no manual casting. Flexible inputs types, fixed output types. Useful parsing error messages
-version: 0.7.1-pre.1
+version: 0.8.0
 homepage: https://github.com/passsy/deep_pick
 
 environment:

--- a/test/src/pick_bool_test.dart
+++ b/test/src/pick_bool_test.dart
@@ -97,8 +97,7 @@ void main() {
       expect(
         // ignore: deprecated_member_use_from_same_package
         () => nullPick().required().asBool(),
-        throwsA(pickException(
-            containing: ['unknownKey', 'absent'])),
+        throwsA(pickException(containing: ['unknownKey', 'absent'])),
       );
     });
 
@@ -113,8 +112,7 @@ void main() {
       );
       expect(
         () => nullPick().required().asBoolOrThrow(),
-        throwsA(pickException(
-            containing: ['unknownKey', 'absent'])),
+        throwsA(pickException(containing: ['unknownKey', 'absent'])),
       );
     });
   });

--- a/test/src/pick_bool_test.dart
+++ b/test/src/pick_bool_test.dart
@@ -62,4 +62,60 @@ void main() {
       );
     });
   });
+
+  group('pick().required().asBool*', () {
+    test('asBoolOrNull()', () {
+      expect(pick(true).required().asBoolOrNull(), isTrue);
+      expect(pick('a').required().asBoolOrNull(), isNull);
+    });
+
+    test('asBoolOrTrue()', () {
+      expect(pick(true).required().asBoolOrTrue(), isTrue);
+      expect(pick(false).required().asBoolOrTrue(), isFalse);
+      expect(pick('a').required().asBoolOrTrue(), isTrue);
+    });
+
+    test('asBoolOrFalse()', () {
+      expect(pick(true).required().asBoolOrFalse(), isTrue);
+      expect(pick(false).required().asBoolOrFalse(), isFalse);
+      expect(pick('a').required().asBoolOrFalse(), isFalse);
+    });
+
+    test('deprecated asBool forwards to asBoolOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick(true).required().asBool(), isTrue);
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('true').required().asBool(), isTrue);
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('false').required().asBool(), isFalse);
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => pick('Bubblegum').required().asBool(),
+        throwsA(pickException(
+            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+      );
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+        () => nullPick().required().asBool(),
+        throwsA(pickException(
+            containing: ['unknownKey', 'absent'])),
+      );
+    });
+
+    test('asBoolOrThrow()', () {
+      expect(pick(true).required().asBoolOrThrow(), isTrue);
+      expect(pick('true').required().asBoolOrThrow(), isTrue);
+      expect(pick('false').required().asBoolOrThrow(), isFalse);
+      expect(
+        () => pick('Bubblegum').required().asBoolOrThrow(),
+        throwsA(pickException(
+            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+      );
+      expect(
+        () => nullPick().required().asBoolOrThrow(),
+        throwsA(pickException(
+            containing: ['unknownKey', 'absent'])),
+      );
+    });
+  });
 }

--- a/test/src/pick_bool_test.dart
+++ b/test/src/pick_bool_test.dart
@@ -36,7 +36,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick('Bubblegum').asBool(),
         throwsA(pickException(
-            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+            containing: ['String', 'Bubblegum', '<root>', 'bool'])),
       );
       expect(
         // ignore: deprecated_member_use_from_same_package
@@ -53,7 +53,7 @@ void main() {
       expect(
         () => pick('Bubblegum').asBoolOrThrow(),
         throwsA(pickException(
-            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+            containing: ['String', 'Bubblegum', '<root>', 'bool'])),
       );
       expect(
         () => nullPick().asBoolOrThrow(),
@@ -92,7 +92,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick('Bubblegum').required().asBool(),
         throwsA(pickException(
-            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+            containing: ['String', 'Bubblegum', '<root>', 'bool'])),
       );
       expect(
         // ignore: deprecated_member_use_from_same_package
@@ -108,7 +108,7 @@ void main() {
       expect(
         () => pick('Bubblegum').required().asBoolOrThrow(),
         throwsA(pickException(
-            containing: ['Bubblegum', 'String', '<root>', 'bool'])),
+            containing: ['String', 'Bubblegum', '<root>', 'bool'])),
       );
       expect(
         () => nullPick().required().asBoolOrThrow(),

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -26,12 +26,6 @@ void main() {
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
           ])),
         );
-
-        expect(
-          () => nullPick().asDateTimeOrThrow(),
-          throwsA(
-              pickException(containing: ['unknownKey', 'null', 'DateTime'])),
-        );
       });
 
       test('wrong type throws', () {
@@ -74,6 +68,70 @@ void main() {
 
       test('wrong type returns null', () {
         expect(pick(Object()).asDateTimeOrNull(), isNull);
+      });
+    });
+  });
+
+  group('pick().required().asDateTime*', () {
+    group('asDateTimeOrThrow', () {
+      test('parse String', () {
+        expect(pick('2012-02-27 13:27:00').required().asDateTimeOrThrow(),
+            DateTime(2012, 2, 27, 13, 27));
+        expect(pick('2012-02-27 13:27:00.123456z').required().asDateTimeOrThrow(),
+            DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
+      });
+
+      test('parse DateTime', () {
+        final time = DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456);
+        expect(pick(time.toString()).required().asDateTimeOrThrow(), time);
+        expect(pick(time).required().asDateTimeOrThrow(), time);
+      });
+
+      test('null throws', () {
+        expect(
+              () => nullPick().required().asDateTimeOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+          ])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+              () => pick(Object()).required().asDateTimeOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as DateTime"
+          ])),
+        );
+        expect(
+              () => pick('Bubblegum').required().asDateTimeOrThrow(),
+          throwsA(
+              pickException(containing: ['Bubblegum', 'String', 'DateTime'])),
+        );
+      });
+    });
+
+    test('deprecated asDateTime forwards to asDateTimeOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('2012-02-27 13:27:00').required().asDateTime(),
+          DateTime(2012, 2, 27, 13, 27));
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+            () => nullPick().required().asDateTime(),
+        throwsA(pickException(containing: [
+          'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+        ])),
+      );
+    });
+
+    group('asDateTimeOrNull', () {
+      test('parse String', () {
+        expect(pick('2012-02-27 13:27:00').required().asDateTimeOrNull(),
+            DateTime(2012, 2, 27, 13, 27));
+      });
+
+      test('wrong type returns null', () {
+        expect(pick(Object()).required().asDateTimeOrNull(), isNull);
       });
     });
   });

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -77,7 +77,8 @@ void main() {
       test('parse String', () {
         expect(pick('2012-02-27 13:27:00').required().asDateTimeOrThrow(),
             DateTime(2012, 2, 27, 13, 27));
-        expect(pick('2012-02-27 13:27:00.123456z').required().asDateTimeOrThrow(),
+        expect(
+            pick('2012-02-27 13:27:00.123456z').required().asDateTimeOrThrow(),
             DateTime.utc(2012, 2, 27, 13, 27, 0, 123, 456));
       });
 
@@ -89,7 +90,7 @@ void main() {
 
       test('null throws', () {
         expect(
-              () => nullPick().required().asDateTimeOrThrow(),
+          () => nullPick().required().asDateTimeOrThrow(),
           throwsA(pickException(containing: [
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
@@ -98,13 +99,13 @@ void main() {
 
       test('wrong type throws', () {
         expect(
-              () => pick(Object()).required().asDateTimeOrThrow(),
+          () => pick(Object()).required().asDateTimeOrThrow(),
           throwsA(pickException(containing: [
             "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as DateTime"
           ])),
         );
         expect(
-              () => pick('Bubblegum').required().asDateTimeOrThrow(),
+          () => pick('Bubblegum').required().asDateTimeOrThrow(),
           throwsA(
               pickException(containing: ['Bubblegum', 'String', 'DateTime'])),
         );
@@ -117,7 +118,7 @@ void main() {
           DateTime(2012, 2, 27, 13, 27));
       expect(
         // ignore: deprecated_member_use_from_same_package
-            () => nullPick().required().asDateTime(),
+        () => nullPick().required().asDateTime(),
         throwsA(pickException(containing: [
           'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
         ])),

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -23,7 +23,7 @@ void main() {
         expect(
           () => nullPick().asDateTimeOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
           ])),
         );
       });
@@ -32,13 +32,13 @@ void main() {
         expect(
           () => pick(Object()).asDateTimeOrThrow(),
           throwsA(pickException(containing: [
-            "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as DateTime"
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as DateTime'
           ])),
         );
         expect(
           () => pick('Bubblegum').asDateTimeOrThrow(),
           throwsA(
-              pickException(containing: ['Bubblegum', 'String', 'DateTime'])),
+              pickException(containing: ['String', 'Bubblegum', 'DateTime'])),
         );
       });
     });
@@ -51,7 +51,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => nullPick().asDateTime(),
         throwsA(pickException(containing: [
-          'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
+          'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
         ])),
       );
     });
@@ -92,7 +92,7 @@ void main() {
         expect(
           () => nullPick().required().asDateTimeOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
         );
       });
@@ -101,13 +101,13 @@ void main() {
         expect(
           () => pick(Object()).required().asDateTimeOrThrow(),
           throwsA(pickException(containing: [
-            "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as DateTime"
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as DateTime'
           ])),
         );
         expect(
           () => pick('Bubblegum').required().asDateTimeOrThrow(),
           throwsA(
-              pickException(containing: ['Bubblegum', 'String', 'DateTime'])),
+              pickException(containing: ['String', 'Bubblegum', 'DateTime'])),
         );
       });
     });
@@ -120,7 +120,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => nullPick().required().asDateTime(),
         throwsA(pickException(containing: [
-          'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+          'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
         ])),
       );
     });

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -90,7 +90,8 @@ void main() {
     group('asDoubleOrThrow', () {
       test('parse double', () {
         expect(pick(1.0).required().asDoubleOrThrow(), 1.0);
-        expect(pick(double.infinity).required().asDoubleOrThrow(), double.infinity);
+        expect(pick(double.infinity).required().asDoubleOrThrow(),
+            double.infinity);
       });
 
       test('parse int', () {
@@ -119,7 +120,7 @@ void main() {
 
       test('null throws', () {
         expect(
-              () => nullPick().required().asDoubleOrThrow(),
+          () => nullPick().required().asDoubleOrThrow(),
           throwsA(pickException(containing: [
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
@@ -128,14 +129,14 @@ void main() {
 
       test('wrong type throws', () {
         expect(
-              () => pick(Object()).required().asDoubleOrThrow(),
+          () => pick(Object()).required().asDoubleOrThrow(),
           throwsA(pickException(containing: [
             'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be parsed as double'
           ])),
         );
 
         expect(
-              () => pick('Bubblegum').required().asDoubleOrThrow(),
+          () => pick('Bubblegum').required().asDoubleOrThrow(),
           throwsA(pickException(containing: ['Bubblegum', 'String', 'double'])),
         );
       });
@@ -146,7 +147,7 @@ void main() {
       expect(pick('1').required().asDouble(), 1.0);
       expect(
         // ignore: deprecated_member_use_from_same_package
-            () => pick(Object()).required().asDouble(),
+        () => pick(Object()).required().asDouble(),
         throwsA(pickException(containing: [
           "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as double"
         ])),

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -39,7 +39,7 @@ void main() {
         expect(
           () => nullPick().asDoubleOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDoubleOrNull() when the value may be null/absent at some point (double?).'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDoubleOrNull() when the value may be null/absent at some point (double?).'
           ])),
         );
       });
@@ -48,13 +48,13 @@ void main() {
         expect(
           () => pick(Object()).asDoubleOrThrow(),
           throwsA(pickException(containing: [
-            'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be parsed as double'
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as double'
           ])),
         );
 
         expect(
           () => pick('Bubblegum').asDoubleOrThrow(),
-          throwsA(pickException(containing: ['Bubblegum', 'String', 'double'])),
+          throwsA(pickException(containing: ['String', 'Bubblegum', 'double'])),
         );
       });
     });
@@ -66,7 +66,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).asDouble(),
         throwsA(pickException(containing: [
-          "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as double"
+          'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as double'
         ])),
       );
     });
@@ -122,7 +122,7 @@ void main() {
         expect(
           () => nullPick().required().asDoubleOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
         );
       });
@@ -131,13 +131,13 @@ void main() {
         expect(
           () => pick(Object()).required().asDoubleOrThrow(),
           throwsA(pickException(containing: [
-            'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be parsed as double'
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as double'
           ])),
         );
 
         expect(
           () => pick('Bubblegum').required().asDoubleOrThrow(),
-          throwsA(pickException(containing: ['Bubblegum', 'String', 'double'])),
+          throwsA(pickException(containing: ['String', 'Bubblegum', 'double'])),
         );
       });
     });
@@ -149,7 +149,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).required().asDouble(),
         throwsA(pickException(containing: [
-          "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as double"
+          'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as double'
         ])),
       );
     });

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -45,7 +45,7 @@ void main() {
 
         expect(
           () => nullPick().asDoubleOrThrow(),
-          throwsA(pickException(containing: ['unknownKey', 'null', 'double'])),
+          throwsA(pickException(containing: ['unknownKey', 'absent', 'double'])),
         );
       });
 

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -42,12 +42,6 @@ void main() {
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDoubleOrNull() when the value may be null/absent at some point (double?).'
           ])),
         );
-
-        expect(
-          () => nullPick().asDoubleOrThrow(),
-          throwsA(
-              pickException(containing: ['unknownKey', 'absent', 'double'])),
-        );
       });
 
       test('wrong type throws', () {
@@ -88,6 +82,84 @@ void main() {
 
       test('wrong type returns null', () {
         expect(pick(Object()).asDoubleOrNull(), isNull);
+      });
+    });
+  });
+
+  group('pick().required().asDouble*', () {
+    group('asDoubleOrThrow', () {
+      test('parse double', () {
+        expect(pick(1.0).required().asDoubleOrThrow(), 1.0);
+        expect(pick(double.infinity).required().asDoubleOrThrow(), double.infinity);
+      });
+
+      test('parse int', () {
+        expect(pick(1).required().asDoubleOrThrow(), 1.0);
+      });
+      test('parse int String', () {
+        expect(pick('1').required().asDoubleOrThrow(), 1.0);
+      });
+
+      test('parse double String', () {
+        expect(pick('1.0').required().asDoubleOrThrow(), 1.0);
+        expect(pick('25.4634').required().asDoubleOrThrow(), 25.4634);
+        expect(pick('12345.01').required().asDoubleOrThrow(), 12345.01);
+      });
+
+      test('parse german doubles', () {
+        expect(pick('1,0').required().asDoubleOrThrow(), 1.0);
+        expect(pick('12345,01').required().asDoubleOrThrow(), 12345.01);
+      });
+
+      test('parse double with separators', () {
+        expect(pick('12,345.01').required().asDoubleOrThrow(), 12345.01);
+        expect(pick('12 345,01').required().asDoubleOrThrow(), 12345.01);
+        expect(pick('12.345,01').required().asDoubleOrThrow(), 12345.01);
+      });
+
+      test('null throws', () {
+        expect(
+              () => nullPick().required().asDoubleOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+          ])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+              () => pick(Object()).required().asDoubleOrThrow(),
+          throwsA(pickException(containing: [
+            'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be parsed as double'
+          ])),
+        );
+
+        expect(
+              () => pick('Bubblegum').required().asDoubleOrThrow(),
+          throwsA(pickException(containing: ['Bubblegum', 'String', 'double'])),
+        );
+      });
+    });
+
+    test('deprecated asDouble forwards to asDoubleOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('1').required().asDouble(), 1.0);
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+            () => pick(Object()).required().asDouble(),
+        throwsA(pickException(containing: [
+          "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as double"
+        ])),
+      );
+    });
+
+    group('asDoubleOrNull', () {
+      test('parse String', () {
+        expect(pick('2012').required().asDoubleOrNull(), 2012);
+      });
+
+      test('wrong type returns null', () {
+        expect(pick(Object()).required().asDoubleOrNull(), isNull);
       });
     });
   });

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -45,7 +45,8 @@ void main() {
 
         expect(
           () => nullPick().asDoubleOrThrow(),
-          throwsA(pickException(containing: ['unknownKey', 'absent', 'double'])),
+          throwsA(
+              pickException(containing: ['unknownKey', 'absent', 'double'])),
         );
       });
 

--- a/test/src/pick_int_test.dart
+++ b/test/src/pick_int_test.dart
@@ -20,7 +20,7 @@ void main() {
         expect(
           () => nullPick().asIntOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asIntOrNull() when the value may be null/absent at some point (int?).'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asIntOrNull() when the value may be null/absent at some point (int?).'
           ])),
         );
       });
@@ -29,13 +29,13 @@ void main() {
         expect(
           () => pick(Object()).asIntOrThrow(),
           throwsA(pickException(containing: [
-            "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as int'
           ])),
         );
 
         expect(
           () => pick('Bubblegum').asIntOrThrow(),
-          throwsA(pickException(containing: ['Bubblegum', 'String', 'int'])),
+          throwsA(pickException(containing: ['String', 'Bubblegum', 'int'])),
         );
       });
     });
@@ -47,7 +47,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).asInt(),
         throwsA(pickException(containing: [
-          "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
+          'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as int'
         ])),
       );
     });
@@ -83,7 +83,7 @@ void main() {
         expect(
           () => nullPick().required().asIntOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
         );
       });
@@ -92,13 +92,13 @@ void main() {
         expect(
           () => pick(Object()).required().asIntOrThrow(),
           throwsA(pickException(containing: [
-            "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as int'
           ])),
         );
 
         expect(
           () => pick('Bubblegum').required().asIntOrThrow(),
-          throwsA(pickException(containing: ['Bubblegum', 'String', 'int'])),
+          throwsA(pickException(containing: ['String', 'Bubblegum', 'int'])),
         );
       });
     });
@@ -110,7 +110,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).asInt(),
         throwsA(pickException(containing: [
-          "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
+          'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as int'
         ])),
       );
     });

--- a/test/src/pick_int_test.dart
+++ b/test/src/pick_int_test.dart
@@ -66,4 +66,63 @@ void main() {
       });
     });
   });
+
+  group('pick().required().asInt*', () {
+    group('asIntOrThrow', () {
+      test('parse Int', () {
+        expect(pick(1).required().asIntOrThrow(), 1);
+        expect(pick(35).required().asIntOrThrow(), 35);
+      });
+
+      test('parse int String', () {
+        expect(pick('1').required().asIntOrThrow(), 1);
+        expect(pick('123').required().asIntOrThrow(), 123);
+      });
+
+      test('null throws', () {
+        expect(
+              () => nullPick().required().asIntOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+          ])),
+        );
+      });
+
+      test('wrong type throws', () {
+        expect(
+              () => pick(Object()).required().asIntOrThrow(),
+          throwsA(pickException(containing: [
+            "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
+          ])),
+        );
+
+        expect(
+              () => pick('Bubblegum').required().asIntOrThrow(),
+          throwsA(pickException(containing: ['Bubblegum', 'String', 'int'])),
+        );
+      });
+    });
+
+    test('deprecated asInt forwards to asIntOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('1').asInt(), 1.0);
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+            () => pick(Object()).asInt(),
+        throwsA(pickException(containing: [
+          "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
+        ])),
+      );
+    });
+
+    group('asIntOrNull', () {
+      test('parse String', () {
+        expect(pick('2012').required().asIntOrNull(), 2012);
+      });
+
+      test('wrong type returns null', () {
+        expect(pick(Object()).required().asIntOrNull(), isNull);
+      });
+    });
+  });
 }

--- a/test/src/pick_int_test.dart
+++ b/test/src/pick_int_test.dart
@@ -81,7 +81,7 @@ void main() {
 
       test('null throws', () {
         expect(
-              () => nullPick().required().asIntOrThrow(),
+          () => nullPick().required().asIntOrThrow(),
           throwsA(pickException(containing: [
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
@@ -90,14 +90,14 @@ void main() {
 
       test('wrong type throws', () {
         expect(
-              () => pick(Object()).required().asIntOrThrow(),
+          () => pick(Object()).required().asIntOrThrow(),
           throwsA(pickException(containing: [
             "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
           ])),
         );
 
         expect(
-              () => pick('Bubblegum').required().asIntOrThrow(),
+          () => pick('Bubblegum').required().asIntOrThrow(),
           throwsA(pickException(containing: ['Bubblegum', 'String', 'int'])),
         );
       });
@@ -108,7 +108,7 @@ void main() {
       expect(pick('1').asInt(), 1.0);
       expect(
         // ignore: deprecated_member_use_from_same_package
-            () => pick(Object()).asInt(),
+        () => pick(Object()).asInt(),
         throwsA(pickException(containing: [
           "value Instance of 'Object' of type Object at location \"<root>\" in pick(<root>) can not be parsed as int"
         ])),

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -5,6 +5,21 @@ import 'pick_test.dart';
 
 void main() {
   group('pick().let*', () {
+    test('.required().let()', () {
+      expect(
+        pick({'name': 'John Snow'}).required().let((pick) => Person.fromPick(pick)),
+        Person(name: 'John Snow'),
+      );
+      expect(
+        pick({'name': 'John Snow'}).required().let((pick) => Person.fromPick(pick)),
+        Person(name: 'John Snow'),
+      );
+      expect(
+            () => nullPick().required().let((pick) => Person.fromPick(pick)),
+        throwsA(pickException(containing: ['unknownKey', 'absent'])),
+      );
+    });
+
     test('letOrThrow()', () {
       expect(
         pick({'name': 'John Snow'}).letOrThrow((pick) => Person.fromPick(pick)),

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -48,14 +48,14 @@ void main() {
       expect(
         () => pick('a').letOrNull((pick) => Person.fromPick(pick)),
         throwsA(pickException(containing: [
-          'required value at location "name" in pick(json, "name" (absent)) is absent.'
+          'Expected a non-null value but location "name" in pick(json, "name" (absent)) is absent.'
         ])),
       );
       expect(
         () => pick({'asdf': 'John Snow'})
             .letOrNull((pick) => Person.fromPick(pick)),
         throwsA(pickException(containing: [
-          'required value at location "name" in pick(json, "name" (absent)) is absent.'
+          'Expected a non-null value but location "name" in pick(json, "name" (absent)) is absent.'
         ])),
       );
     });
@@ -68,7 +68,7 @@ void main() {
       expect(
         () => nullPick().letOrThrow((pick) => Person.fromPick(pick)),
         throwsA(pickException(containing: [
-          'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use letOrNull() when the value may be null/absent at some point.'
+          'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use letOrNull() when the value may be null/absent at some point.'
         ])),
       );
       expect(
@@ -76,7 +76,7 @@ void main() {
             .letOrThrow((pick) => Person.fromPick(pick)),
         throwsA(
           pickException(containing: [
-            'required value at location "name" in pick(json, "name" (absent)) is absent. Use letOrNull() when the value may be null/absent at some point.'
+            'Expected a non-null value but location "name" in pick(json, "name" (absent)) is absent. Use letOrNull() when the value may be null/absent at some point'
           ]),
         ),
       );

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -7,15 +7,19 @@ void main() {
   group('pick().let*', () {
     test('.required().let()', () {
       expect(
-        pick({'name': 'John Snow'}).required().let((pick) => Person.fromPick(pick)),
+        pick({'name': 'John Snow'})
+            .required()
+            .let((pick) => Person.fromPick(pick)),
         Person(name: 'John Snow'),
       );
       expect(
-        pick({'name': 'John Snow'}).required().let((pick) => Person.fromPick(pick)),
+        pick({'name': 'John Snow'})
+            .required()
+            .let((pick) => Person.fromPick(pick)),
         Person(name: 'John Snow'),
       );
       expect(
-            () => nullPick().required().let((pick) => Person.fromPick(pick)),
+        () => nullPick().required().let((pick) => Person.fromPick(pick)),
         throwsA(pickException(containing: ['unknownKey', 'absent'])),
       );
     });

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -7,12 +7,12 @@ void main() {
   group('pick().asList*', () {
     group('asListOrThrow', () {
       test('pipe through List', () {
-        expect(pick([1, 2, 3]).asListOrThrow((it) => it.asInt()), [1, 2, 3]);
+        expect(pick([1, 2, 3]).asListOrThrow((it) => it.asIntOrThrow()), [1, 2, 3]);
       });
 
       test('null throws', () {
         expect(
-          () => nullPick().asListOrThrow((it) => it.asString()),
+          () => nullPick().asListOrThrow((it) => it.asStringOrThrow()),
           throwsA(pickException(containing: [
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<String>?).'
           ])),
@@ -86,12 +86,12 @@ void main() {
 
       test('wrong type throws', () {
         expect(
-          () => pick('Bubblegum').asListOrThrow((it) => it.asString()),
+          () => pick('Bubblegum').asListOrThrow((it) => it.asStringOrThrow()),
           throwsA(pickException(
               containing: ['Bubblegum', 'String', 'List<dynamic>'])),
         );
         expect(
-          () => pick(Object()).asListOrThrow((it) => it.asString()),
+          () => pick(Object()).asListOrThrow((it) => it.asStringOrThrow()),
           throwsA(pickException(containing: [
             'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be casted to List<dynamic>'
           ])),
@@ -113,15 +113,15 @@ void main() {
 
     group('asListOrEmpty', () {
       test('pick value', () {
-        expect(pick([1, 2, 3]).asListOrEmpty((it) => it.asInt()), [1, 2, 3]);
+        expect(pick([1, 2, 3]).asListOrEmpty((it) => it.asIntOrThrow()), [1, 2, 3]);
       });
 
       test('null returns null', () {
-        expect(nullPick().asListOrEmpty((it) => it.asInt()), []);
+        expect(nullPick().asListOrEmpty((it) => it.asIntOrThrow()), []);
       });
 
       test('wrong type returns empty', () {
-        expect(pick(Object()).asListOrEmpty((it) => it.asInt()), []);
+        expect(pick(Object()).asListOrEmpty((it) => it.asIntOrThrow()), []);
       });
 
       test('map empty list to empty list', () {
@@ -199,15 +199,15 @@ void main() {
 
     group('asListOrNull', () {
       test('pick value', () {
-        expect(pick([1, 2, 3]).asListOrNull((it) => it.asInt()), [1, 2, 3]);
+        expect(pick([1, 2, 3]).asListOrNull((it) => it.asIntOrThrow()), [1, 2, 3]);
       });
 
       test('null returns null', () {
-        expect(nullPick().asListOrNull((it) => it.asInt()), isNull);
+        expect(nullPick().asListOrNull((it) => it.asIntOrThrow()), isNull);
       });
 
       test('wrong type returns empty', () {
-        expect(pick(Object()).asListOrNull((it) => it.asInt()), isNull);
+        expect(pick(Object()).asListOrNull((it) => it.asIntOrThrow()), isNull);
       });
 
       test('map empty list to empty list', () {

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -15,7 +15,7 @@ void main() {
         expect(
           () => nullPick().asListOrThrow((it) => it.asStringOrThrow()),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<String>?).'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<String>?).'
           ])),
         );
       });
@@ -80,7 +80,7 @@ void main() {
             {'asdf': 'Daenerys Targaryen'}, // <-- missing name key
           ]).asListOrThrow((pick) => Person.fromPick(pick)),
           throwsA(pickException(containing: [
-            'required value at location list index 1 in pick(json, 1 (absent), "name") is absent. Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<Person>?).'
+            'Expected a non-null value but location list index 1 in pick(json, 1 (absent), "name") is absent. Use asListOrEmpty()/asListOrNull() when the value may be null/absent at some point (List<Person>?).'
           ])),
         );
       });
@@ -89,12 +89,12 @@ void main() {
         expect(
           () => pick('Bubblegum').asListOrThrow((it) => it.asStringOrThrow()),
           throwsA(pickException(
-              containing: ['Bubblegum', 'String', 'List<dynamic>'])),
+              containing: ['String', 'Bubblegum', 'List<dynamic>'])),
         );
         expect(
           () => pick(Object()).asListOrThrow((it) => it.asStringOrThrow()),
           throwsA(pickException(containing: [
-            'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be casted to List<dynamic>'
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be casted to List<dynamic>'
           ])),
         );
       });
@@ -107,7 +107,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).asList(),
         throwsA(pickException(containing: [
-          'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be casted to List<dynamic>'
+          'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be casted to List<dynamic>'
         ])),
       );
     });
@@ -193,7 +193,7 @@ void main() {
             {'asdf': 'Daenerys Targaryen'}, // <-- missing name key
           ]).asListOrEmpty((pick) => Person.fromPick(pick)),
           throwsA(pickException(containing: [
-            'required value at location list index 1 in pick(json, 1 (absent), "name") is absent.'
+            'Expected a non-null value but location list index 1 in pick(json, 1 (absent), "name") is absent.'
           ])),
         );
       });
@@ -281,7 +281,7 @@ void main() {
         expect(
           () => pick(data).asListOrNull((pick) => Person.fromPick(pick)),
           throwsA(pickException(containing: [
-            'required value at location list index 1 in pick(json, 1 (absent), "name") is absent.'
+            'Expected a non-null value but location list index 1 in pick(json, 1 (absent), "name") is absent.'
           ])),
         );
       });

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -7,7 +7,8 @@ void main() {
   group('pick().asList*', () {
     group('asListOrThrow', () {
       test('pipe through List', () {
-        expect(pick([1, 2, 3]).asListOrThrow((it) => it.asIntOrThrow()), [1, 2, 3]);
+        expect(pick([1, 2, 3]).asListOrThrow((it) => it.asIntOrThrow()),
+            [1, 2, 3]);
       });
 
       test('null throws', () {
@@ -113,7 +114,8 @@ void main() {
 
     group('asListOrEmpty', () {
       test('pick value', () {
-        expect(pick([1, 2, 3]).asListOrEmpty((it) => it.asIntOrThrow()), [1, 2, 3]);
+        expect(pick([1, 2, 3]).asListOrEmpty((it) => it.asIntOrThrow()),
+            [1, 2, 3]);
       });
 
       test('null returns null', () {
@@ -199,7 +201,8 @@ void main() {
 
     group('asListOrNull', () {
       test('pick value', () {
-        expect(pick([1, 2, 3]).asListOrNull((it) => it.asIntOrThrow()), [1, 2, 3]);
+        expect(
+            pick([1, 2, 3]).asListOrNull((it) => it.asIntOrThrow()), [1, 2, 3]);
       });
 
       test('null returns null', () {

--- a/test/src/pick_map_test.dart
+++ b/test/src/pick_map_test.dart
@@ -14,7 +14,7 @@ void main() {
         expect(
           () => nullPick().asMapOrThrow<String, bool>(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asMapOrEmpty()/asMapOrNull() when the value may be null/absent at some point (Map<String, bool>?).'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asMapOrEmpty()/asMapOrNull() when the value may be null/absent at some point (Map<String, bool>?).'
           ])),
         );
       });
@@ -60,12 +60,12 @@ void main() {
         expect(
           () => pick('Bubblegum').asMapOrThrow(),
           throwsA(pickException(
-              containing: ['Bubblegum', 'String', 'Map<dynamic, dynamic>'])),
+              containing: ['String', 'Bubblegum', 'Map<dynamic, dynamic>'])),
         );
         expect(
           () => pick(Object()).asMapOrThrow(),
           throwsA(pickException(containing: [
-            'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be casted to Map<dynamic, dynamic>'
+            'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be casted to Map<dynamic, dynamic>'
           ])),
         );
       });
@@ -78,7 +78,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         () => pick(Object()).asMap(),
         throwsA(pickException(containing: [
-          'value Instance of \'Object\' of type Object at location "<root>" in pick(<root>) can not be casted to Map<dynamic, dynamic>'
+          'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be casted to Map<dynamic, dynamic>'
         ])),
       );
     });

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -88,10 +88,8 @@ void main() {
       });
     });
 
-    test('deprecated asString forwards to asStringOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
+    test('required().asString()', () {
       expect(pick('adam').required().asString(), 'adam');
-      // ignore: deprecated_member_use_from_same_package
       expect(pick([]).required().asString(), '[]');
     });
   });

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -53,5 +53,76 @@ void main() {
         expect(pick(Object()).asStringOrNull(), "Instance of 'Object'");
       });
     });
+
+    test('deprecated asString forwards to asStringOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('adam').asString(), 'adam');
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+            () => pick([]).asString(),
+        throwsA(pickException(containing: [
+          'value at location "<root>" in pick(<root>) is of type List<dynamic>. Drill further down to a value which is not a List or Map. value: []'
+        ])),
+      );
+    });
+  });
+
+  group('pick().required().asString*', () {
+    group('asStringOrThrow', () {
+      test('parse anything to String', () {
+        expect(pick('adam').required().asStringOrThrow(), 'adam');
+        expect(pick(1).required().asStringOrThrow(), '1');
+        expect(pick(2.0).required().asStringOrThrow(), '2.0');
+        expect(
+            pick(DateTime(2000)).required().asStringOrThrow(), '2000-01-01 00:00:00.000');
+      });
+
+      test("asString() doesn't transform Maps and Lists with toString", () {
+        expect(
+              () => pick(['a', 'b']).required().asStringOrThrow(),
+          throwsA(pickException(
+              containing: ['List<String>', 'not a List or Map', '[a, b]'])),
+        );
+        expect(
+              () => pick({'a': 'b'}).required().asStringOrThrow(),
+          throwsA(pickException(containing: [
+            'Map<String, String>',
+            'not a List or Map',
+            '{a: b}'
+          ])),
+        );
+      });
+
+      test('null throws', () {
+        expect(
+              () => nullPick().required().asStringOrThrow(),
+          throwsA(pickException(containing: [
+            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+          ])),
+        );
+      });
+    });
+
+    group('asStringOrNull', () {
+      test('parse String', () {
+        expect(pick('2012').required().asStringOrNull(), '2012');
+      });
+
+      test('as long it is not null it prints toString', () {
+        expect(pick(Object()).required().asStringOrNull(), "Instance of 'Object'");
+      });
+    });
+
+    test('deprecated asString forwards to asStringOrThrow', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick('adam').required().asString(), 'adam');
+      expect(
+        // ignore: deprecated_member_use_from_same_package
+            () => pick([]).required().asString(),
+        throwsA(pickException(containing: [
+          'value at location "<root>" in pick(<root>) is of type List<dynamic>. Drill further down to a value which is not a List or Map. value: []'
+        ])),
+      );
+    });
   });
 }

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -40,18 +40,6 @@ void main() {
       });
     });
 
-    test('deprecated asString forwards to asStringOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('1').asString(), '1');
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => nullPick().asString(),
-        throwsA(pickException(containing: [
-          'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asStringOrNull() when the value may be null/absent at some point (String?).'
-        ])),
-      );
-    });
-
     group('asStringOrNull', () {
       test('parse String', () {
         expect(pick('2012').asStringOrNull(), '2012');

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -14,20 +14,9 @@ void main() {
             pick(DateTime(2000)).asStringOrThrow(), '2000-01-01 00:00:00.000');
       });
 
-      test("asString() doesn't transform Maps and Lists with toString", () {
-        expect(
-          () => pick(['a', 'b']).asStringOrThrow(),
-          throwsA(pickException(
-              containing: ['List<String>', 'not a List or Map', '[a, b]'])),
-        );
-        expect(
-          () => pick({'a': 'b'}).asStringOrThrow(),
-          throwsA(pickException(containing: [
-            'Map<String, String>',
-            'not a List or Map',
-            '{a: b}'
-          ])),
-        );
+      test('asString() alsow works for Maps and Lists calling their toString', () {
+        expect(pick(['a', 'b']).asStringOrThrow(), '[a, b]');
+        expect(pick({'a': 1}).asStringOrThrow(), '{a: 1}');
       });
 
       test('null throws', () {
@@ -57,13 +46,8 @@ void main() {
     test('deprecated asString forwards to asStringOrThrow', () {
       // ignore: deprecated_member_use_from_same_package
       expect(pick('adam').asString(), 'adam');
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick([]).asString(),
-        throwsA(pickException(containing: [
-          'value at location "<root>" in pick(<root>) is of type List<dynamic>. Drill further down to a value which is not a List or Map. value: []'
-        ])),
-      );
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick([]).asString(), '[]');
     });
   });
 
@@ -78,19 +62,8 @@ void main() {
       });
 
       test("asString() doesn't transform Maps and Lists with toString", () {
-        expect(
-          () => pick(['a', 'b']).required().asStringOrThrow(),
-          throwsA(pickException(
-              containing: ['List<String>', 'not a List or Map', '[a, b]'])),
-        );
-        expect(
-          () => pick({'a': 'b'}).required().asStringOrThrow(),
-          throwsA(pickException(containing: [
-            'Map<String, String>',
-            'not a List or Map',
-            '{a: b}'
-          ])),
-        );
+        expect(pick(['a', 'b']).required().asStringOrThrow(), '[a, b]');
+        expect(pick({'a': 1}).required().asStringOrThrow(), '{a: 1}');
       });
 
       test('null throws', () {
@@ -117,13 +90,8 @@ void main() {
     test('deprecated asString forwards to asStringOrThrow', () {
       // ignore: deprecated_member_use_from_same_package
       expect(pick('adam').required().asString(), 'adam');
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick([]).required().asString(),
-        throwsA(pickException(containing: [
-          'value at location "<root>" in pick(<root>) is of type List<dynamic>. Drill further down to a value which is not a List or Map. value: []'
-        ])),
-      );
+      // ignore: deprecated_member_use_from_same_package
+      expect(pick([]).required().asString(), '[]');
     });
   });
 }

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -14,7 +14,8 @@ void main() {
             pick(DateTime(2000)).asStringOrThrow(), '2000-01-01 00:00:00.000');
       });
 
-      test('asString() alsow works for Maps and Lists calling their toString', () {
+      test('asString() alsow works for Maps and Lists calling their toString',
+          () {
         expect(pick(['a', 'b']).asStringOrThrow(), '[a, b]');
         expect(pick({'a': 1}).asStringOrThrow(), '{a: 1}');
       });
@@ -23,7 +24,7 @@ void main() {
         expect(
           () => nullPick().asStringOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asStringOrNull() when the value may be null/absent at some point (String?).'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asStringOrNull() when the value may be null/absent at some point (String?).'
           ])),
         );
       });
@@ -70,7 +71,7 @@ void main() {
         expect(
           () => nullPick().required().asStringOrThrow(),
           throwsA(pickException(containing: [
-            'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
+            'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
         );
       });

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -59,7 +59,7 @@ void main() {
       expect(pick('adam').asString(), 'adam');
       expect(
         // ignore: deprecated_member_use_from_same_package
-            () => pick([]).asString(),
+        () => pick([]).asString(),
         throwsA(pickException(containing: [
           'value at location "<root>" in pick(<root>) is of type List<dynamic>. Drill further down to a value which is not a List or Map. value: []'
         ])),
@@ -73,18 +73,18 @@ void main() {
         expect(pick('adam').required().asStringOrThrow(), 'adam');
         expect(pick(1).required().asStringOrThrow(), '1');
         expect(pick(2.0).required().asStringOrThrow(), '2.0');
-        expect(
-            pick(DateTime(2000)).required().asStringOrThrow(), '2000-01-01 00:00:00.000');
+        expect(pick(DateTime(2000)).required().asStringOrThrow(),
+            '2000-01-01 00:00:00.000');
       });
 
       test("asString() doesn't transform Maps and Lists with toString", () {
         expect(
-              () => pick(['a', 'b']).required().asStringOrThrow(),
+          () => pick(['a', 'b']).required().asStringOrThrow(),
           throwsA(pickException(
               containing: ['List<String>', 'not a List or Map', '[a, b]'])),
         );
         expect(
-              () => pick({'a': 'b'}).required().asStringOrThrow(),
+          () => pick({'a': 'b'}).required().asStringOrThrow(),
           throwsA(pickException(containing: [
             'Map<String, String>',
             'not a List or Map',
@@ -95,7 +95,7 @@ void main() {
 
       test('null throws', () {
         expect(
-              () => nullPick().required().asStringOrThrow(),
+          () => nullPick().required().asStringOrThrow(),
           throwsA(pickException(containing: [
             'required value at location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
           ])),
@@ -109,7 +109,8 @@ void main() {
       });
 
       test('as long it is not null it prints toString', () {
-        expect(pick(Object()).required().asStringOrNull(), "Instance of 'Object'");
+        expect(
+            pick(Object()).required().asStringOrNull(), "Instance of 'Object'");
       });
     });
 
@@ -118,7 +119,7 @@ void main() {
       expect(pick('adam').required().asString(), 'adam');
       expect(
         // ignore: deprecated_member_use_from_same_package
-            () => pick([]).required().asString(),
+        () => pick([]).required().asString(),
         throwsA(pickException(containing: [
           'value at location "<root>" in pick(<root>) is of type List<dynamic>. Drill further down to a value which is not a List or Map. value: []'
         ])),

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -280,7 +280,7 @@ class Person {
 
   factory Person.fromPick(RequiredPick pick) {
     return Person(
-      name: pick('name').required().asString(),
+      name: pick('name').required().asStringOrThrow(),
     );
   }
 

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -11,46 +11,78 @@ void main() {
 
     test('required pick from null show good error message', () {
       expect(
-          () => pick(null).required(),
-          throwsA(isA<PickException>().having(
-            (e) => e.message,
-            'message',
-            contains(
-                'required value at location "<root>" in pick(<root>) is null'),
-          )));
+        () => pick(null).required(),
+        throwsA(isA<PickException>().having(
+          (e) => e.message,
+          'message',
+          contains(
+              'Expected a non-null value but location picked value "null" using pick(<root>) is null'),
+        )),
+      );
     });
 
-    test('pick null but require - show good error message', () {
-      expect(
-          () => pick([null], 0).required(),
-          throwsA(isA<PickException>().having(
-            (e) => e.message,
-            'message',
-            contains(
-                'required value at location list index 0 in pick(json, 0 (null)) is null'),
-          )));
+    group('location', () {
+      test('root with value', () {
+        expect(
+            pick('a').debugParsingExit, 'picked value "a" using pick(<root>)');
+      });
+      test('root with null', () {
+        expect(pick(null).debugParsingExit,
+            'picked value "null" using pick(<root>)');
+      });
+
+      test('absent in map', () {
+        expect(pick({'a': 1}, 'b').debugParsingExit,
+            '"b" in pick(json, "b" (absent))');
+      });
+      test('null in map', () {
+        expect(pick({'a': null}, 'a').debugParsingExit,
+            'picked value "null" using pick(json, "a" (null))');
+      });
+      test('value in map', () {
+        expect(pick({'a': 'b'}, 'a').debugParsingExit,
+            'picked value "b" using pick(json, "a"(b))');
+      });
+
+      test('long path', () {
+        expect(pick({'a': 'b'}, 'a', 'b', 'c', 'd').debugParsingExit,
+            '"b" in pick(json, "a", "b" (absent), "c", "d")');
+      });
     });
 
-    test('required pick from null with args show good error message', () {
-      expect(
-          () => pick(null, 'some', 'path').required(),
-          throwsA(isA<PickException>().having(
-            (e) => e.message,
-            'message',
-            contains(
-                'required value at location "some" in pick(json, "some" (absent), "path") is absent'),
-          )));
-    });
+    group('required', () {
+      test('pick null but require - show good error message', () {
+        expect(
+            () => pick([null], 0).required(),
+            throwsA(isA<PickException>().having(
+              (e) => e.message,
+              'message',
+              contains(
+                  'Expected a non-null value but location picked value "null" using pick(json, 0 (null)) is null'),
+            )));
+      });
 
-    test('not matching required pick show good error message', () {
-      expect(
-          () => pick('a', 'some', 'path').required(),
-          throwsA(isA<PickException>().having(
-            (e) => e.message,
-            'message',
-            contains(
-                'required value at location "some" in pick(json, "some" (absent), "path") is absent'),
-          )));
+      test('required pick from null with args show good error message', () {
+        expect(
+            () => pick(null, 'some', 'path').required(),
+            throwsA(isA<PickException>().having(
+              (e) => e.message,
+              'message',
+              contains(
+                  'Expected a non-null value but location "some" in pick(json, "some" (absent), "path") is absent'),
+            )));
+      });
+
+      test('not matching required pick show good error message', () {
+        expect(
+            () => pick('a', 'some', 'path').required(),
+            throwsA(isA<PickException>().having(
+              (e) => e.message,
+              'message',
+              contains(
+                  'Expected a non-null value but location "some" in pick(json, "some" (absent), "path") is absent.'),
+            )));
+      });
     });
 
     test('toString() prints value and path', () {

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -8,6 +8,14 @@ void main() {
       expect(RequiredPick('a', path: ['b', 0]).toString(),
           'RequiredPick(value=a, path=[b, 0])');
     });
+
+    test('value is non nullable', (){
+      final nullable = pick('a');
+      expect([nullable.value].runtimeType.toString(), 'List<Object?>');
+
+      final nonNull = nullable.required();
+      expect([nonNull.value].runtimeType.toString(), 'List<Object>');
+    });
   });
 
   group('.call()', () {

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -9,7 +9,7 @@ void main() {
           'RequiredPick(value=a, path=[b, 0])');
     });
 
-    test('value is non nullable', (){
+    test('value is non nullable', () {
       final nullable = pick('a');
       expect([nullable.value].runtimeType.toString(), 'List<Object?>');
 

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -71,10 +71,9 @@ void main() {
       expect(root.context, {'lang': 'de'});
 
       final contexts = root.asList((pick) => pick.context);
-      expect(contexts, [
-        {'lang': 'de'},
-        {'lang': 'de'}
-      ]);
+      // only check the lang fields, ignore the _required_pick_error_hint
+      expect(contexts[0]['lang'], 'de');
+      expect(contexts[1]['lang'], 'de');
     });
 
     test('copy context into call()', () {

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -78,10 +78,11 @@ void main() {
       root.context['lang'] = 'de';
       expect(root.context, {'lang': 'de'});
 
-      final contexts = root.asList((pick) => pick.context);
-      // only check the lang fields, ignore the _required_pick_error_hint
-      expect(contexts[0]['lang'], 'de');
-      expect(contexts[1]['lang'], 'de');
+      final contexts = root.asListOrEmpty((pick) => pick.context);
+      expect(contexts, [
+        {'lang': 'de'},
+        {'lang': 'de'}
+      ]);
     });
 
     test('copy context into call()', () {


### PR DESCRIPTION
This PR almost removes the `RequiredPick` class for simplicity. While it makes sense that `Pick` holds a potential `null` value and `RequiredPick` doesn't it is not useful for users of this library.

Until now it was used this way:

```dart
final name = pick(json, 'shoes', 0, 'name').asStringOrThrow();
final name = pick(json, 'shoes', 0, 'name').required().asString(); // <-- no OrThrow
```

by calling `.required()` the pick was converted to a `RequiredPick` making sure the `value` is not `null`. I initially thought that it would make parsing easier and users don't have to write `.asStringOrThrow()` but only `.asString()` because the value can't be `null`.

The mistake is that `null` or absence of the value is not the only cause for a crash! It might also crash when parsing doesn't work. `"asdf"` can't be parsed to `bool`. 

Therefore `.required().asBool()` should always be written as 
- `.required().asBoolOrThrow()` or 
- `.required().asBoolOrNull()`
to make sure crashes are handled intentionally or a default value is given.
 

## Todos

- [ ] Update readme, clarify required usage
- [ ] list map tests
- [ ] document `location()`
- [ ] document constructors
