### PR TITLE
Add Pick.index to get the element index for list items

### DIFF
--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -123,6 +123,19 @@ class Pick {
   /// i.e the HTTP request/response including headers
   final Map<String, dynamic> context;
 
+  /// The index of the object when it is an element in a `List`
+  int? get index {
+    final lastPathSegment = path.isNotEmpty ? path.last : null;
+    if (lastPathSegment == null) {
+      return null;
+    }
+    if (lastPathSegment is int) {
+      // within a List
+      return lastPathSegment;
+    }
+    return null;
+  }
+
   /// When the picked value is unavailable ([Pick..absent]) the index in
   /// [path] which couldn't be found
   int? get missingValueAtIndex => _missingValueAtIndex;

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -124,6 +124,15 @@ class Pick {
   final Map<String, dynamic> context;
 
   /// The index of the object when it is an element in a `List`
+  ///
+  /// Usage:
+  ///
+  /// ```dart
+  /// pick(["John", "Paul", "George", "Ringo"]).asListOrThrow((pick) {
+  ///  final index = pick.index!;
+  ///  return Artist(id: index, name: pick.asStringOrThrow());
+  /// );
+  /// ```
   int? get index {
     final lastPathSegment = path.isNotEmpty ? path.last : null;
     if (lastPathSegment == null) {

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -303,8 +303,14 @@ void main() {
           (pick) => MapEntry(pick.asStringOrThrow(), pick.index),
           whenNull: (pick) => MapEntry(pick.index, pick.index! * 2),
         );
-        expect(Map.fromEntries(entries),
-            {'a': 0, 1: 2, 2: 4, 'b': 3, 4: 8, 'c': 5});
+        expect(Map.fromEntries(entries), {
+          'a': 0,
+          1: 2,
+          2: 4,
+          'b': 3,
+          4: 8,
+          'c': 5,
+        });
       });
     });
   });

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -286,5 +286,26 @@ void main() {
         );
       });
     });
+
+    group('index in asList* items', () {
+      test('index is available in lists', () {
+        final entries = pick(['a', 'b', 'c']).asListOrThrow(
+            (pick) => MapEntry(pick.asStringOrThrow(), pick.index));
+        expect(Map.fromEntries(entries), {'a': 0, 'b': 1, 'c': 2});
+      });
+      test('index increments for null values', () {
+        final entries = pick(['a', null, null, 'b', null, 'c']).asListOrThrow(
+            (pick) => MapEntry(pick.asStringOrThrow(), pick.index));
+        expect(Map.fromEntries(entries), {'a': 0, 'b': 3, 'c': 5});
+      });
+      test('whenNull has access to index', () {
+        final entries = pick(['a', null, null, 'b', null, 'c']).asListOrThrow(
+          (pick) => MapEntry(pick.asStringOrThrow(), pick.index),
+          whenNull: (pick) => MapEntry(pick.index, pick.index! * 2),
+        );
+        expect(Map.fromEntries(entries),
+            {'a': 0, 1: 2, 2: 4, 'b': 3, 4: 8, 'c': 5});
+      });
+    });
   });
 }

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -293,6 +293,30 @@ void main() {
       expect(root.context, {'lang': 'de', 'hello': 'world'});
       expect(afterCall.context, {'lang': 'de'});
     });
+
+    group('index', () {
+      test('index is available in lists', () {
+        final picked0 = pick(['a', 'b', 'c'], 0);
+        expect(picked0.index, 0);
+        expect(picked0.value, 'a');
+
+        final picked1 = pick(['a', 'b', 'c'], 1);
+        expect(picked1.index, 1);
+        expect(picked1.value, 'b');
+
+        final picked2 = pick(['a', 'b', 'c'], 2);
+        expect(picked2.index, 2);
+        expect(picked2.value, 'c');
+      });
+      test('index increments for null values', () {
+        final picked = pick(['a', null, 'c'], 1);
+        expect(picked.index, 1);
+        expect(picked.value, null);
+      });
+      test('no index for maps', () {
+        expect(pick({'a': 'apple', 'b': 'beer'}, 'a').index, isNull);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Usage:

```dart
pick(["John", "Paul", "George", "Ringo"]).asListOrThrow((pick) {
  final index = pick.index!;
  return Artist(id: index, name: pick.asStringOrThrow());
);
```

The index has always been available via `path` but was never explicitly exposed. `deep_pick` users started incrementing their own `indices` which is unnecessary