### PR TITLE
Parse HTTP "Date" header

### DIFF
--- a/lib/deep_pick.dart
+++ b/lib/deep_pick.dart
@@ -2,6 +2,7 @@ export 'package:deep_pick/src/pick.dart' hide requiredPickErrorHintKey;
 export 'package:deep_pick/src/pick_bool.dart';
 export 'package:deep_pick/src/pick_datetime.dart';
 export 'package:deep_pick/src/pick_double.dart';
+export 'package:deep_pick/src/pick_http_date.dart';
 export 'package:deep_pick/src/pick_int.dart';
 export 'package:deep_pick/src/pick_let.dart';
 export 'package:deep_pick/src/pick_list.dart';

--- a/lib/src/pick_http_date.dart
+++ b/lib/src/pick_http_date.dart
@@ -1,0 +1,215 @@
+import 'package:deep_pick/src/pick.dart';
+
+extension NullableDateHeaderPick on Pick {
+  /// {@template Pick.asHttpDate}
+  /// Parses the `Date` http header String of the formats
+  /// [RFC-1123](http://tools.ietf.org/html/rfc1123 'RFC-1123'),
+  /// [RFC-850](http://tools.ietf.org/html/rfc850 'RFC-850') or
+  /// ANSI C's asctime() format. These formats are listed here.
+  ///
+  ///     Thu, 1 Jan 1970 00:00:00 GMT
+  ///     Thursday, 1-Jan-1970 00:00:00 GMT
+  ///     Thu Jan  1 00:00:00 1970
+  ///
+  /// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+  /// {@endtemplate}
+  DateTime _parse() {
+    final value = required().value;
+    if (value is DateTime) {
+      return value;
+    }
+    if (value is String) {
+      // not using HttpDate.parse because it is not available in the browsers
+      return _parseHttpDate(value);
+    }
+    throw PickException(
+        'Type ${value.runtimeType} of $debugParsingExit can not be parsed as DateTime');
+  }
+
+  /// Parses the picked [value] as [DateTime] or throws
+  ///
+  /// {@macro Pick.asHttpDate}
+  DateTime asHttpDateOrThrow() {
+    withContext(requiredPickErrorHintKey,
+        'Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).');
+    return _parse();
+  }
+
+  /// Parses the picked [value] as [DateTime] or returns `null`
+  ///
+  /// {@macro Pick.asHttpDate}
+  DateTime? asHttpDateOrNull() {
+    if (value == null) return null;
+    try {
+      return _parse();
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+enum _DateHeaderFormat {
+  formatRfc1123,
+  formatRfc850,
+  formatAsctime,
+}
+
+DateTime _parseHttpDate(String date) {
+  const asciiSpace = 32;
+  const wkdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const weekdays = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday'
+  ];
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec'
+  ];
+
+  var index = 0;
+  String tmp;
+
+  _DateHeaderFormat expectWeekday() {
+    int weekday;
+    // The formatting of the weekday signals the format of the date string.
+    final pos = date.indexOf(',', index);
+    if (pos == -1) {
+      final pos = date.indexOf(' ', index);
+      if (pos == -1) throw FormatException('Invalid HTTP date $date');
+      tmp = date.substring(index, pos);
+      index = pos + 1;
+      weekday = wkdays.indexOf(tmp);
+      if (weekday != -1) {
+        return _DateHeaderFormat.formatAsctime;
+      }
+    } else {
+      tmp = date.substring(index, pos);
+      index = pos + 1;
+      weekday = wkdays.indexOf(tmp);
+      if (weekday != -1) {
+        return _DateHeaderFormat.formatRfc1123;
+      }
+      weekday = weekdays.indexOf(tmp);
+      if (weekday != -1) {
+        return _DateHeaderFormat.formatRfc850;
+      }
+    }
+    throw FormatException('Invalid HTTP date $date');
+  }
+
+  void expect(String s) {
+    if (date.length - index < s.length) {
+      throw FormatException('Invalid HTTP date $date');
+    }
+    final tmp = date.substring(index, index + s.length);
+    if (tmp != s) {
+      throw FormatException('Invalid HTTP date $date');
+    }
+    index += s.length;
+  }
+
+  int expectMonth(String separator) {
+    final pos = date.indexOf(separator, index);
+    if (pos - index != 3) throw FormatException('Invalid HTTP date $date');
+    tmp = date.substring(index, pos);
+    index = pos + 1;
+    final month = months.indexOf(tmp);
+    if (month != -1) return month;
+    throw FormatException('Invalid HTTP date $date');
+  }
+
+  int expectNum(String separator, {int? maxDigits, int? minDigits}) {
+    int pos;
+    if (separator.isNotEmpty) {
+      pos = date.indexOf(separator, index);
+    } else {
+      pos = date.length;
+    }
+    try {
+      final tmp = date.substring(index, pos);
+      if (maxDigits != null && tmp.length > maxDigits) {
+        throw FormatException('Expected max a $maxDigits-digits number');
+      }
+      if (minDigits != null && tmp.length < minDigits) {
+        throw FormatException('Expected a least a $minDigits-digits number');
+      }
+
+      index = pos + separator.length;
+      final value = int.parse(tmp);
+      return value;
+      // ignore: avoid_catching_errors
+    } on RangeError {
+      throw FormatException('Expected a $maxDigits-digits number');
+    }
+  }
+
+  void expectEnd() {
+    if (index != date.length) {
+      throw FormatException('Invalid HTTP date $date');
+    }
+  }
+
+  final format = expectWeekday();
+  int year;
+  int month;
+  int day;
+  int hours;
+  int minutes;
+  int seconds;
+
+  switch (format) {
+    case _DateHeaderFormat.formatRfc1123:
+      expect(' ');
+      day = expectNum(' ', minDigits: 1, maxDigits: 2);
+      month = expectMonth(' ');
+      year = expectNum(' ', minDigits: 4, maxDigits: 4);
+      hours = expectNum(':', minDigits: 1, maxDigits: 2);
+      minutes = expectNum(':', minDigits: 1, maxDigits: 2);
+      seconds = expectNum(' ', minDigits: 1, maxDigits: 2);
+      expect('GMT');
+      break;
+    case _DateHeaderFormat.formatRfc850:
+      expect(' ');
+      day = expectNum('-', minDigits: 1, maxDigits: 2);
+      month = expectMonth('-');
+      year = expectNum(' ', minDigits: 2, maxDigits: 4);
+      if (year < 100) {
+        year = 1900 + year;
+      }
+      hours = expectNum(':', minDigits: 1, maxDigits: 2);
+      minutes = expectNum(':', minDigits: 1, maxDigits: 2);
+      seconds = expectNum(' ', minDigits: 1, maxDigits: 2);
+      expect('GMT');
+      break;
+    case _DateHeaderFormat.formatAsctime:
+      month = expectMonth(' ');
+      if (date.codeUnitAt(index) == asciiSpace) index++;
+      day = expectNum(' ', minDigits: 1, maxDigits: 3);
+      hours = expectNum(':', minDigits: 1, maxDigits: 2);
+      minutes = expectNum(':', minDigits: 1, maxDigits: 2);
+      seconds = expectNum(' ', minDigits: 1, maxDigits: 2);
+      year = expectNum('', minDigits: 2, maxDigits: 4);
+      if (year < 100) {
+        year = 1900 + year;
+      }
+      break;
+  }
+  expectEnd();
+  //ignore: avoid_redundant_argument_values
+  return DateTime.utc(year, month + 1, day, hours, minutes, seconds, 0, 0);
+}

--- a/test/src/pick_http_date.dart
+++ b/test/src/pick_http_date.dart
@@ -1,0 +1,386 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('asHttpDateHeaderOrThrow', () {
+    group('official dart tests', () {
+      test('1', () {
+        final date = DateTime.utc(1999, DateTime.june, 11, 18, 46, 53);
+        expect(pick('Fri, 11 Jun 1999 18:46:53 GMT').asHttpDateOrThrow(), date);
+        expect(
+            pick('Friday, 11-Jun-1999 18:46:53 GMT').asHttpDateOrThrow(), date);
+        expect(pick('Fri Jun 11 18:46:53 1999').asHttpDateOrThrow(), date);
+      });
+
+      test('2', () {
+        final date = DateTime.utc(1970, DateTime.january);
+        expect(pick('Thu, 1 Jan 1970 00:00:00 GMT').asHttpDateOrThrow(), date);
+        expect(pick('Thursday, 1-Jan-1970 00:00:00 GMT').asHttpDateOrThrow(),
+            date);
+        expect(pick('Thu Jan  1 00:00:00 1970').asHttpDateOrThrow(), date);
+      });
+
+      test('3', () {
+        final date = DateTime.utc(2012, DateTime.march, 5, 23, 59, 59);
+        expect(pick('Mon, 5 Mar 2012 23:59:59 GMT').asHttpDateOrThrow(), date);
+        expect(
+            pick('Monday, 5-Mar-2012 23:59:59 GMT').asHttpDateOrThrow(), date);
+        expect(pick('Mon Mar  5 23:59:59 2012').asHttpDateOrThrow(), date);
+      });
+    });
+
+    group('RFC 1123', () {
+      test('parses the example date', () {
+        final date = pick('Sun, 06 Nov 1994 08:49:37 GMT').asHttpDateOrThrow();
+        expect(date.day, equals(6));
+        expect(date.month, equals(DateTime.november));
+        expect(date.year, equals(1994));
+        expect(date.hour, equals(8));
+        expect(date.minute, equals(49));
+        expect(date.second, equals(37));
+        expect(date.timeZoneName, equals('UTC'));
+      });
+
+      test('whitespace is required', () {
+        expect(() => pick('Sun,06 Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06 Nov1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06 Nov 199408:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06 Nov 1994 08:49:37GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('exactly one space is required', () {
+        expect(() => pick('Sun,  06 Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06  Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06 Nov  1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06 Nov 1994  08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun, 06 Nov 1994 08:49:37  GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      // Be flexible on input
+      test('Do not require precise number lengths', () {
+        // short day
+        expect(pick('Sun, 6 Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+
+        // short hour
+        expect(pick('Sun, 06 Nov 1994 8:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+
+        // short min
+        expect(pick('Sun, 06 Nov 1994 08:9:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 9, 37));
+
+        // short seconds
+        expect(pick('Sun, 06 Nov 1994 08:49:7 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 7));
+      });
+
+      test('accepts days out of month range', () {
+        // negative days
+        expect(pick('Sun, 00 Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 10, 31, 8, 49, 37));
+
+        // day overlap
+        expect(pick('Sun, 31 Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 12, 01, 8, 49, 37));
+
+        // day overlap
+        expect(pick('Sun, 32 Aug 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 09, 01, 8, 49, 37));
+
+        // hours overlap
+        expect(pick('Sun, 06 Nov 1994 24:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 07, 0, 49, 37));
+
+        // minutes overlap
+        expect(pick('Sun, 06 Nov 1994 08:60:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 06, 9, 00, 37));
+
+        // seconds overlap
+        expect(pick('Sun, 06 Nov 1994 08:49:60 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 06, 8, 50));
+      });
+
+      test('requires reasonable numbers', () {
+        // short year
+        expect(() => pick('Sun, 06 Nov 94 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('only allows short weekday names', () {
+        expect(
+            () => pick('Sunday, 6 Nov 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('only allows short month names', () {
+        expect(
+            () => pick('Sun, 6 November 1994 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('only allows GMT', () {
+        expect(() => pick('Sun, 6 Nov 1994 08:49:37 PST').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('disallows trailing whitespace', () {
+        expect(() => pick('Sun, 6 Nov 1994 08:49:37 GMT ').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+    });
+
+    group('RFC 850', () {
+      test('parses the example date', () {
+        final date = pick('Sunday, 06-Nov-94 08:49:37 GMT').asHttpDateOrThrow();
+        expect(date.day, equals(6));
+        expect(date.month, equals(DateTime.november));
+        expect(date.year, equals(1994));
+        expect(date.hour, equals(8));
+        expect(date.minute, equals(49));
+        expect(date.second, equals(37));
+        expect(date.timeZoneName, equals('UTC'));
+      });
+
+      test('whitespace is required', () {
+        expect(() => pick('Sunday,06-Nov-94 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sunday, 06-Nov-9408:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sunday, 06-Nov-94 08:49:37GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('exactly one space is required', () {
+        expect(
+            () => pick('Sunday,  06-Nov-94 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(
+            () => pick('Sunday, 06-Nov-94  08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(
+            () => pick('Sunday, 06-Nov-94 08:49:37  GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('Do not require precise number lengths', () {
+        // short day
+        expect(pick('Sunday, 6-Nov-94 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+
+        // short hour
+        expect(pick('Sunday, 06-Nov-94 8:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+
+        // long year
+        expect(pick('Sunday, 06-Nov-1994 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+        expect(pick('Sunday, 06-Nov-2018 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(2018, 11, 6, 8, 49, 37));
+
+        // short min
+        expect(pick('Sunday, 06-Nov-94 08:9:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 9, 37));
+
+        // short seconds
+        expect(pick('Sunday, 06-Nov-94 08:49:7 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 7));
+      });
+
+      test('accepts invalid dates', () {
+        // negative days
+        expect(pick('Sunday, 00-Nov-94 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 10, 31, 8, 49, 37));
+
+        // day overlap
+        expect(pick('Sunday, 31-Nov-94 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 12, 01, 8, 49, 37));
+
+        // day overlap
+        expect(pick('Sunday, 32-Aug-94 08:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 09, 01, 8, 49, 37));
+
+        // hours overlap
+        expect(pick('Sunday, 06-Nov-94 24:49:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 07, 0, 49, 37));
+
+        // minutes overlap
+        expect(pick('Sunday, 06-Nov-94 08:60:37 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 06, 9, 00, 37));
+
+        // seconds overlap
+        expect(pick('Sunday, 06-Nov-94 08:49:60 GMT').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 06, 8, 50));
+      });
+
+      test('only allows long weekday names', () {
+        expect(() => pick('Sun, 6-Nov-94 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('only allows short month names', () {
+        expect(
+            () =>
+                pick('Sunday, 6-November-94 08:49:37 GMT').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('only allows GMT', () {
+        expect(() => pick('Sunday, 6-Nov-94 08:49:37 PST').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('disallows trailing whitespace', () {
+        expect(() => pick('Sunday, 6-Nov-94 08:49:37 GMT ').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+    });
+
+    group('asctime()', () {
+      test('parses the example date', () {
+        final date = pick('Sun Nov  6 08:49:37 1994').asHttpDateOrThrow();
+        expect(date.day, equals(6));
+        expect(date.month, equals(DateTime.november));
+        expect(date.year, equals(1994));
+        expect(date.hour, equals(8));
+        expect(date.minute, equals(49));
+        expect(date.second, equals(37));
+        expect(date.timeZoneName, equals('UTC'));
+      });
+
+      test('parses a date with a two-digit day', () {
+        final date = pick('Sun Nov 16 08:49:37 1994').asHttpDateOrThrow();
+        expect(date.day, equals(16));
+        expect(date.month, equals(DateTime.november));
+        expect(date.year, equals(1994));
+        expect(date.hour, equals(8));
+        expect(date.minute, equals(49));
+        expect(date.second, equals(37));
+        expect(date.timeZoneName, equals('UTC'));
+      });
+
+      test('parses a date with a single-digit day', () {
+        final date = pick('Sun Nov  1 08:49:37 1994').asHttpDateOrThrow();
+        expect(date.day, equals(1));
+        expect(date.month, equals(DateTime.november));
+        expect(date.year, equals(1994));
+        expect(date.hour, equals(8));
+        expect(date.minute, equals(49));
+        expect(date.second, equals(37));
+        expect(date.timeZoneName, equals('UTC'));
+      });
+
+      test('whitespace is required', () {
+        expect(() => pick('SunNov  6 08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun Nov6 08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun Nov  608:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun Nov  6 08:49:371994').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('the right amount of whitespace is required', () {
+        expect(() => pick('Sun  Nov  6 08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun Nov   6 08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(pick('Sun Nov 6 08:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+
+        expect(() => pick('Sun Nov  6  08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+
+        expect(() => pick('Sun Nov  6 08:49:37  1994').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('requires precise number lengths', () {
+        expect(pick('Sun Nov 016 08:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 16, 8, 49, 37));
+
+        expect(pick('Sun Nov  6 8:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+
+        expect(pick('Sun Nov  6 08:9:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 9, 37));
+
+        expect(pick('Sun Nov  6 08:49:7 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 7));
+
+        expect(pick('Sun Nov  6 08:49:37 94').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 6, 8, 49, 37));
+      });
+
+      test('accepts invalid dates', () {
+        // negative days
+        expect(pick('Sun Nov 0 08:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 10, 31, 8, 49, 37));
+
+        // day overlap
+        expect(pick('Sun Nov 31 08:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 12, 01, 8, 49, 37));
+
+        // day overlap
+        expect(pick('Sun Aug 32 08:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 09, 01, 8, 49, 37));
+
+        // hours overlap
+        expect(pick('Sun Nov  6 24:49:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 07, 0, 49, 37));
+
+        // minutes overlap
+        expect(pick('Sun Nov  6 08:60:37 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 06, 9, 00, 37));
+
+        // seconds overlap
+        expect(pick('Sun Nov  6 08:49:60 1994').asHttpDateOrThrow(),
+            DateTime.utc(1994, 11, 06, 8, 50));
+      });
+
+      test('only allows short weekday names', () {
+        expect(() => pick('Sunday Nov 0 08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('only allows short month names', () {
+        expect(() => pick('Sun November 0 08:49:37 1994').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+
+      test('disallows trailing whitespace', () {
+        expect(() => pick('Sun November 0 08:49:37 1994 ').asHttpDateOrThrow(),
+            throwsFormatException);
+      });
+    });
+  });
+}


### PR DESCRIPTION
The [HTTP Date header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date) can't be parsed with `DateTime.parse`, it doesn't follow the `ISO 8601` standard. Instead if follows the format 

```
Date: <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT
```

Dart offers `HttpDate.parse` in the `dart:io` package, but it's not available on `web`. The regex implementation here works cross platform.

This PR adds `Pick.asHttpDateOrThrow()` and `Pick.asHttpDateOrNull()`.

### Discussion

Should it be merged with `Pick.asDateTime()`?

 