### PR TITLE
Remove deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## future release
+
+- Remove long deprecated methods: `addContext`, `asBool`, `asDateTime`, `asDouble`, `asInt`, `asList`, `asMap`, `asString`. Use their `as*OrThrow` replacements.
+- 
+
+
 ## 0.10.0 (`01.10.21`)
 
 - New: Support for more date formats. `asDateTime*` received an optional `format` parameter. By default, all possible formats will be parsed. To the existing `ISO 8601` format, `RFC 1123`, `RFC 850` and `asctime` have been added which are typically used for the HTTP header or cookies.

--- a/lib/src/pick.dart
+++ b/lib/src/pick.dart
@@ -315,10 +315,6 @@ class Pick {
     return this;
   }
 
-  // Has been removed in 0.5.0
-  @Deprecated('Use withContext')
-  Pick Function(String key, dynamic value) get addContext => withContext;
-
   /// Pick values from the context using the [Pick] API
   ///
   /// ```
@@ -436,12 +432,6 @@ class RequiredPick extends Pick {
   String toString() => 'RequiredPick(value=$value, path=$path)';
 
   Pick nullable() => Pick(value, path: path, context: context);
-
-  // Has been removed in 0.5.0
-  @Deprecated('Use withContext')
-  @override
-  RequiredPick Function(String key, dynamic value) get addContext =>
-      withContext;
 
   @override
   RequiredPick withContext(String key, Object? value) {

--- a/lib/src/pick_bool.dart
+++ b/lib/src/pick_bool.dart
@@ -35,9 +35,6 @@ extension BoolPick on Pick {
     );
   }
 
-  @Deprecated('Use .asBoolOrThrow()')
-  bool Function() get asBool => asBoolOrThrow;
-
   /// Returns the picked [value] as [bool] or throws a [PickException]
   ///
   /// {@macro Pick.asBool}

--- a/lib/src/pick_datetime.dart
+++ b/lib/src/pick_datetime.dart
@@ -59,9 +59,6 @@ enum PickDateFormat {
 }
 
 extension NullableDateTimePick on Pick {
-  @Deprecated('Use .asDateTimeOrThrow()')
-  DateTime Function() get asDateTime => asDateTimeOrThrow;
-
   /// Parses the picked non-null [value] as [DateTime] or throws
   ///
   /// {@template Pick.asDateTime}

--- a/lib/src/pick_double.dart
+++ b/lib/src/pick_double.dart
@@ -1,9 +1,6 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension NullableDoublePick on Pick {
-  @Deprecated('Use .asDoubleOrThrow()')
-  double Function() get asDouble => asDoubleOrThrow;
-
   /// Returns the picked [value] as [double]
   ///
   /// {@template Pick.asDouble}

--- a/lib/src/pick_int.dart
+++ b/lib/src/pick_int.dart
@@ -1,9 +1,6 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension NullableIntPick on Pick {
-  @Deprecated('Use .asIntOrThrow()')
-  int Function() get asInt => asIntOrThrow;
-
   /// Returns the picked [value] as [int]
   ///
   /// {@template Pick.asInt}

--- a/lib/src/pick_list.dart
+++ b/lib/src/pick_list.dart
@@ -1,17 +1,6 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension NullableListPick on Pick {
-  @Deprecated('Use .asListOrThrow()')
-  List<T> asList<T>([T Function(Pick)? map]) {
-    return asListOrThrow(
-      (it) {
-        final mapFn = map ?? (Pick it) => it.value as T;
-        return mapFn(it.nullable());
-      },
-      whenNull: (it) => it.value as T,
-    );
-  }
-
   /// Returns the items of the [List] as list, mapped each item with [map]
   ///
   /// {@template Pick.asList}

--- a/lib/src/pick_map.dart
+++ b/lib/src/pick_map.dart
@@ -1,9 +1,6 @@
 import 'package:deep_pick/src/pick.dart';
 
 extension NullableMapPick on Pick {
-  @Deprecated('Use .asMapOrThrow()')
-  Map<RK, RV> Function<RK, RV>() get asMap => asMapOrThrow;
-
   /// Returns the picked [value] as [Map]
   ///
   /// {@template Pick.asMap}

--- a/lib/src/pick_string.dart
+++ b/lib/src/pick_string.dart
@@ -8,9 +8,6 @@ extension RequiredStringPick on RequiredPick {
 }
 
 extension NullableStringPick on Pick {
-  @Deprecated('Use .asStringOrThrow()')
-  String Function() get asString => asStringOrThrow;
-
   /// Returns the picked [value] as [String] representation
   ///
   /// {@template Pick.asString}

--- a/test/src/pick_bool_test.dart
+++ b/test/src/pick_bool_test.dart
@@ -25,31 +25,6 @@ void main() {
       expect(nullPick().asBoolOrFalse(), isFalse);
     });
 
-    test('deprecated asBool forwards to asBoolOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick(true).asBool(), isTrue);
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('true').asBool(), isTrue);
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('false').asBool(), isFalse);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick('Bubblegum').asBool(),
-        throwsA(
-          pickException(containing: ['String', 'Bubblegum', '<root>', 'bool']),
-        ),
-      );
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => nullPick().asBool(),
-        throwsA(
-          pickException(
-            containing: ['unknownKey', 'asBoolOrNull', 'null', 'bool?'],
-          ),
-        ),
-      );
-    });
-
     test('asBoolOrThrow()', () {
       expect(pick(true).asBoolOrThrow(), isTrue);
       expect(pick('true').asBoolOrThrow(), isTrue);
@@ -87,27 +62,6 @@ void main() {
       expect(pick(true).required().asBoolOrFalse(), isTrue);
       expect(pick(false).required().asBoolOrFalse(), isFalse);
       expect(pick('a').required().asBoolOrFalse(), isFalse);
-    });
-
-    test('deprecated asBool forwards to asBoolOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick(true).required().asBool(), isTrue);
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('true').required().asBool(), isTrue);
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('false').required().asBool(), isFalse);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick('Bubblegum').required().asBool(),
-        throwsA(
-          pickException(containing: ['String', 'Bubblegum', '<root>', 'bool']),
-        ),
-      );
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => nullPick().required().asBool(),
-        throwsA(pickException(containing: ['unknownKey', 'absent'])),
-      );
     });
 
     test('asBoolOrThrow()', () {

--- a/test/src/pick_datetime_test.dart
+++ b/test/src/pick_datetime_test.dart
@@ -56,25 +56,6 @@ void main() {
       });
     });
 
-    test('deprecated asDateTime forwards to asDateTimeOrThrow', () {
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        pick('2012-02-27 13:27:00').asDateTime(),
-        DateTime(2012, 2, 27, 13, 27),
-      );
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => nullPick().asDateTime(),
-        throwsA(
-          pickException(
-            containing: [
-              'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent. Use asDateTimeOrNull() when the value may be null/absent at some point (DateTime?).'
-            ],
-          ),
-        ),
-      );
-    });
-
     group('asDateTimeOrNull', () {
       test('parse String', () {
         expect(
@@ -143,25 +124,6 @@ void main() {
           ),
         );
       });
-    });
-
-    test('deprecated asDateTime forwards to asDateTimeOrThrow', () {
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        pick('2012-02-27 13:27:00').required().asDateTime(),
-        DateTime(2012, 2, 27, 13, 27),
-      );
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => nullPick().required().asDateTime(),
-        throwsA(
-          pickException(
-            containing: [
-              'Expected a non-null value but location "unknownKey" in pick(json, "unknownKey" (absent)) is absent.'
-            ],
-          ),
-        ),
-      );
     });
 
     group('asDateTimeOrNull', () {

--- a/test/src/pick_double_test.dart
+++ b/test/src/pick_double_test.dart
@@ -67,22 +67,6 @@ void main() {
       });
     });
 
-    test('deprecated asDouble forwards to asDoubleOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('1').asDouble(), 1.0);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick(Object()).asDouble(),
-        throwsA(
-          pickException(
-            containing: [
-              'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as double'
-            ],
-          ),
-        ),
-      );
-    });
-
     group('asDoubleOrNull', () {
       test('parse String', () {
         expect(pick('2012').asDoubleOrNull(), 2012);
@@ -162,22 +146,6 @@ void main() {
           throwsA(pickException(containing: ['String', 'Bubblegum', 'double'])),
         );
       });
-    });
-
-    test('deprecated asDouble forwards to asDoubleOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('1').required().asDouble(), 1.0);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick(Object()).required().asDouble(),
-        throwsA(
-          pickException(
-            containing: [
-              'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as double'
-            ],
-          ),
-        ),
-      );
     });
 
     group('asDoubleOrNull', () {

--- a/test/src/pick_int_test.dart
+++ b/test/src/pick_int_test.dart
@@ -71,22 +71,6 @@ void main() {
       });
     });
 
-    test('deprecated asInt forwards to asIntOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('1').asInt(), 1.0);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick(Object()).asInt(),
-        throwsA(
-          pickException(
-            containing: [
-              'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as int'
-            ],
-          ),
-        ),
-      );
-    });
-
     group('asIntOrNull', () {
       test('parse String', () {
         expect(pick('2012').asIntOrNull(), 2012);
@@ -144,22 +128,6 @@ void main() {
           throwsA(pickException(containing: ['String', 'Bubblegum', 'int'])),
         );
       });
-    });
-
-    test('deprecated asInt forwards to asIntOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('1').asInt(), 1.0);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick(Object()).asInt(),
-        throwsA(
-          pickException(
-            containing: [
-              'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be parsed as int'
-            ],
-          ),
-        ),
-      );
     });
 
     group('asIntOrNull', () {

--- a/test/src/pick_list_test.dart
+++ b/test/src/pick_list_test.dart
@@ -117,22 +117,6 @@ void main() {
       });
     });
 
-    test('deprecated asList forwards to asListOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick([1, 2, 3]).asList<int>(), [1, 2, 3]);
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick(Object()).asList(),
-        throwsA(
-          pickException(
-            containing: [
-              'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be casted to List<dynamic>'
-            ],
-          ),
-        ),
-      );
-    });
-
     group('asListOrEmpty', () {
       test('pick value', () {
         expect(

--- a/test/src/pick_map_test.dart
+++ b/test/src/pick_map_test.dart
@@ -46,21 +46,6 @@ void main() {
               ),
             ),
           );
-          // ignore: avoid_catching_errors, deprecated_member_use
-        } on CastError catch (e) {
-          // backwards compatibility for Dart 2.7
-          // CastError was replaced with TypeError in Dart 2.8
-          expect(
-            e,
-            // ignore: deprecated_member_use
-            const TypeMatcher<CastError>().having(
-              (e) => e.toString(),
-              'message',
-              stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool'],
-              ),
-            ),
-          );
         }
       });
 
@@ -84,22 +69,6 @@ void main() {
           ),
         );
       });
-    });
-
-    test('deprecated asMap forwards to asMapOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick({'ab': 'cd'}).asMap(), {'ab': 'cd'});
-      expect(
-        // ignore: deprecated_member_use_from_same_package
-        () => pick(Object()).asMap(),
-        throwsA(
-          pickException(
-            containing: [
-              'Type Object of picked value "Instance of \'Object\'" using pick(<root>) can not be casted to Map<dynamic, dynamic>'
-            ],
-          ),
-        ),
-      );
     });
 
     group('asMapOrEmpty', () {
@@ -139,20 +108,6 @@ void main() {
             ),
           );
           // ignore: avoid_catching_errors, deprecated_member_use
-        } on CastError catch (e) {
-          // backwards compatibility for Dart 2.7
-          // CastError was replaced with TypeError in Dart 2.8
-          expect(
-            e,
-            // ignore: deprecated_member_use
-            const TypeMatcher<CastError>().having(
-              (e) => e.toString(),
-              'message',
-              stringContainsInOrder(
-                ['<String, String>', 'is not a subtype of type', 'bool'],
-              ),
-            ),
-          );
         }
       });
     });

--- a/test/src/pick_string_test.dart
+++ b/test/src/pick_string_test.dart
@@ -49,13 +49,6 @@ void main() {
         expect(pick(Object()).asStringOrNull(), "Instance of 'Object'");
       });
     });
-
-    test('deprecated asString forwards to asStringOrThrow', () {
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick('adam').asString(), 'adam');
-      // ignore: deprecated_member_use_from_same_package
-      expect(pick([]).asString(), '[]');
-    });
   });
 
   group('pick().required().asString*', () {

--- a/test/src/pick_test.dart
+++ b/test/src/pick_test.dart
@@ -359,12 +359,6 @@ void main() {
       expect(root.context, {'lang': 'de'});
     });
 
-    test('add and read from context with syntax sugar (deprecated)', () {
-      // ignore: deprecated_member_use_from_same_package
-      final root = pick([]).addContext('lang', 'de');
-      expect(root.fromContext('lang').asStringOrNull(), 'de');
-    });
-
     test('read from deep nested context', () {
       final root = pick([]).withContext('user', {'id': '1234'});
       expect(root.fromContext('user', 'id').asStringOrNull(), '1234');

--- a/test/src/required_pick_test.dart
+++ b/test/src/required_pick_test.dart
@@ -60,12 +60,6 @@ void main() {
       expect(root.context, {'lang': 'de'});
     });
 
-    test('add and read from context with syntax sugar (deprecated)', () {
-      // ignore: deprecated_member_use_from_same_package
-      final root = pick([]).required().addContext('lang', 'de');
-      expect(root.fromContext('lang').asStringOrNull(), 'de');
-    });
-
     test('read from deep nested context', () {
       final root = pick([]).required().withContext('user', {'id': '1234'});
       expect(root.fromContext('user', 'id').asStringOrNull(), '1234');


### PR DESCRIPTION
All APIs where deprecated months ago, the replacement APIs are easy discoverable.

There are no public packages [depending on `deep_pick`](https://pub.dev/packages?q=dependency%3Adeep_pick). As disappointing as it seems, it's great that it doesn't break anyones package.

Checking public repositories showed people actually using deep_pick (yay), but nobody uses the deprecated APIs.