### PR TITLE
Allow letOrNull to return R?

### DIFF
--- a/lib/src/pick_let.dart
+++ b/lib/src/pick_let.dart
@@ -59,7 +59,7 @@ extension NullableLet on Pick {
   ///   user = User.fromJson(pick.asMap());
   /// }
   /// ```
-  R? letOrNull<R>(R Function(RequiredPick pick) block) {
+  R? letOrNull<R>(R? Function(RequiredPick pick) block) {
     if (value == null) return null;
     return block(required());
   }

--- a/test/src/pick_let_test.dart
+++ b/test/src/pick_let_test.dart
@@ -45,6 +45,10 @@ void main() {
         Person(name: 'John Snow'),
       );
       expect(nullPick().letOrNull((pick) => Person.fromPick(pick)), isNull);
+      // allow lambda to return null
+      final String? a = pick('a').letOrNull((pick) => null);
+      expect(a, isNull);
+      expect(pick('a').letOrNull((pick) => null), isNull);
       expect(
         () => pick('a').letOrNull((pick) => Person.fromPick(pick)),
         throwsA(


### PR DESCRIPTION
Before

```dart
final String? a = pick('a').letOrNull((pick) => null);
// error: The return type 'Null' isn't a 'String', as required by the closure's context. (return_of_invalid_type_from_closure

// Workaround
final String? a = pick('a').letOrNull<String?>((pick) => null);
```

After

```dart
final String? a = pick('a').letOrNull((pick) => null); // no error
```